### PR TITLE
feat: add GitHub Container Registry publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Development files
+.roo
+data
+dist
+node_modules
+
+# Environment files
+.env*
+
+# Documentation
+*.md
+
+# Git and GitHub
+.git
+.github
+.gitignore
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+
+# Test files
+**/*.spec.ts
+**/*.test.ts
+
+# CI/CD
+.dockerignore
+docker-compose.yml
+
+# Logs
+*.log
+npm-debug.log*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,50 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,38 @@ npm test
 
 ## Dockerを使用したデプロイ
 
-### 環境変数の設定
+### GitHub Container Registryからイメージを取得する
+
+このプロジェクトのDockerイメージはGitHub Container Registryで公開されています。
+
+```bash
+# 最新版を取得
+docker pull ghcr.io/ta-dadadada/trrbot-ts-bolt:latest
+
+# 特定のバージョンを取得
+docker pull ghcr.io/ta-dadadada/trrbot-ts-bolt:1.0.0
+```
+
+公開イメージを使用してコンテナを起動する場合：
+
+```bash
+# .envファイルを作成して環境変数を設定
+cp .env.example .env
+# .envファイルを編集してSlack APIトークンを設定
+
+# コンテナを起動
+docker run -d \
+  --name trrbot \
+  --env-file .env \
+  -v trrbot-data:/app/data \
+  ghcr.io/ta-dadadada/trrbot-ts-bolt:latest
+```
+
+### ローカルでイメージをビルドする
+
+公開イメージを使用せず、ローカルでDockerイメージをビルドすることもできます。
+
+#### 環境変数の設定
 
 1. `.env.example`ファイルをコピーして`.env`ファイルを作成します：
 
@@ -49,7 +80,7 @@ SLACK_APP_TOKEN=xapp-your-app-token
 PORT=3000
 ```
 
-### Dockerイメージのビルドと起動
+#### Dockerイメージのビルドと起動
 
 ```bash
 # イメージをビルドしてコンテナを起動


### PR DESCRIPTION
## 概要
GitHub Container Registry (ghcr.io) へのコンテナイメージ自動公開設定を追加しました。

## 変更内容
- ✅ GitHub Actions ワークフローの追加 (`.github/workflows/docker-publish.yml`)
  - main ブランチへの push 時に自動ビルド・公開
  - `v*.*.*` 形式のタグ push 時にバージョン番号でタグ付け
  - `latest` タグとセマンティックバージョンタグを自動生成
- ✅ README の更新
  - GitHub Container Registry からのイメージ取得方法を追加
  - `docker pull` / `docker run` のコマンド例を記載
- ✅ `.dockerignore` の改善
  - Git関連ファイル、テストファイル、CI/CD設定などを除外
  - イメージサイズとビルド時間の最適化

## 動作確認
このPRがマージされると、GitHub Actions が自動的に実行され、`ghcr.io/ta-dadadada/trrbot-ts-bolt:latest` としてイメージが公開されます。

## 関連Issue
Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)