### PR TITLE
fix(ci): use check-regexp instead of check-name in auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -24,7 +24,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.4.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'build'
+          check-regexp: 'build'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
 


### PR DESCRIPTION
## Summary
- Fix the auto-merge workflow to correctly wait for CI checks
- Change `check-name: 'build'` to `check-regexp: 'build'`

## Problem
The auto-merge workflow was failing with the error:
```
The requested check was never run against this ref, exiting...
```

This happened because the workflow was looking for a check named `'build'`, but the actual check name is `'CI / build'` (GitHub Actions uses the format `<workflow-name> / <job-name>`).

## Solution
Use `check-regexp` instead of `check-name` to allow flexible pattern matching. This will match any check containing "build" in its name, making the workflow more resilient to workflow name changes.

## Test plan
- [ ] Verify this PR's auto-merge workflow completes successfully
- [ ] Confirm future dependabot PRs are automatically merged when appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)