### PR TITLE
chore(ci): prevent @types/node major version updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+    ignore:
+      # Node.js v22 LTSに固定するため、@types/nodeのメジャーバージョンアップを抑止
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions依存関係の更新
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Dependabotの設定に`@types/node`のメジャーバージョンアップデート抑止ルールを追加
- Node.js v22 LTSの型定義を維持しながら、マイナー・パッチバージョンは自動更新される

## 変更内容
`.github/dependabot.yml`に以下のignoreルールを追加：
```yaml
ignore:
  - dependency-name: "@types/node"
    update-types: ["version-update:semver-major"]
```

## 影響
- `@types/node` v22.x.x → v23.x.x のようなメジャーバージョンアップデートは抑止
- `@types/node` v22.18.x → v22.19.x のようなマイナー・パッチバージョンは引き続き自動更新

## Test plan
- [ ] Dependabotの設定ファイルが正しいYAML形式であることを確認
- [ ] マージ後、DependabotがメジャーバージョンアップデートのPRを作成しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)