### PR TITLE
Fix dependency vulnerability in brace-expansion package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1883,9 +1883,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Updated `brace-expansion` from 1.1.11 to 1.1.12 to fix ReDoS vulnerability (GHSA-v6h2-p8h4-qcjw)
- Verified all tests pass (46/46)
- Confirmed build succeeds
- No new vulnerabilities introduced

## Test Plan
- [x] Run `npm audit fix`
- [x] Verify all tests pass (`npm test`)
- [x] Confirm build succeeds (`npm run build`)
- [x] Verify no new vulnerabilities (`npm audit` reports 0 vulnerabilities)

## Related
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)