### PR TITLE
fix(deps): js-yaml脆弱性(CVE-2025-64718)の修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4272,9 +4272,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 概要
Dependabotアラート#6に対応し、js-yamlのプロトタイプ汚染脆弱性を修正しました。

## 変更内容
- js-yamlを4.1.0から4.1.1にアップデート
- CVE-2025-64718 (プロトタイプ汚染) を修正

## 脆弱性詳細
- **脆弱性**: CVE-2025-64718 - Prototype Pollution in merge (<<)
- **影響範囲**: 開発依存関係のみ (transitive dependency)
- **深刻度**: Medium (CVSS 5.3)
- **修正バージョン**: 4.1.1以上

## テスト結果
- ✅ 全124テストがパス
- ✅ Lintエラーなし
- ✅ 型チェックエラーなし
- ✅ 脆弱性スキャン: found 0 vulnerabilities

## 関連
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)