### PR TITLE
ci: migrate setup, lint, auto-merge jobs to ubuntu-slim (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node.js
@@ -33,7 +33,7 @@ jobs:
 
   lint:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node.js

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # Dependabotが作成したPRのみ対象
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:


### PR DESCRIPTION
## 概要

Issue #72 のPhase 1として、安全性の高い3つのCIジョブをubuntu-slimランナーに移行します。

## 変更内容

### 移行したジョブ

1. **`ci.yml` → `setup` ジョブ**
   - 操作: `npm ci`（依存関係インストール）
   - 理由: I/Oバウンドで軽量、1 vCPUで十分

2. **`ci.yml` → `lint` ジョブ**
   - 操作: ESLint + TypeScript型チェック
   - 理由: GitHub公式がlintingをubuntu-slim推奨用途として明記

3. **`dependabot-auto-merge.yml` → `auto-merge` ジョブ**
   - 操作: GitHub CLI APIコールのみ
   - 理由: 最も軽量で理想的なユースケース

### 変更箇所

```diff
- runs-on: ubuntu-latest
+ runs-on: ubuntu-slim
```

## Ubuntu-Slimランナーの仕様

- **CPU:** 1 vCPU (ubuntu-latestは4 vCPU)
- **メモリ:** 5 GB RAM (ubuntu-latestは16 GB)
- **ストレージ:** 14 GB SSD
- **最大実行時間:** 15分

## 期待される効果

- **コスト削減:** 3ジョブでの料金削減
- **パフォーマンス影響:** 最小限（これらのジョブはI/Oバウンドで軽量）
- **実行時間:** 許容範囲内（15分制限に対して十分な余裕）

## 安全性評価

| ジョブ | リスク | 理由 |
|--------|--------|------|
| setup | 低 | 依存関係インストールは軽量 |
| lint | 低 | lintingは公式推奨用途 |
| auto-merge | 非常に低 | APIコールのみ、最も軽量 |

## 参考資料

- [GitHub hosted runners - Standard runners](https://docs.github.com/ja/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
- [1 vCPU Linux runner announcement](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/)

## 次のステップ (Phase 2)

このPRマージ後、以下のジョブを別ブランチでテスト予定:
- `test` ジョブ（better-sqlite3のネイティブコンパイル検証が必要）
- `build` ジョブ（ビルド時間のモニタリングが必要）

Closes #72 (Phase 1)