### PR TITLE
fix(ci): unify all jobs to ubuntu-slim for cache consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
   test:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node.js
@@ -77,7 +77,7 @@ jobs:
 
   build:
     needs: [lint, test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
- test と build ジョブの `runs-on` を `ubuntu-latest` から `ubuntu-slim` に変更
- setup/lint ジョブが `ubuntu-slim` を使用していたため、キャッシュキーの不一致が発生していた
- これにより `node_modules` キャッシュが復元されず、`vitest: not found` エラーが発生

## Root Cause
キャッシュキーは `${{ runner.os }}-node-modules-{hash}` 形式で、OS名は同じ `Linux` だが、
実際には異なるランナー環境のため、setup で作成したキャッシュが test/build で見つからなかった。

## Test plan
- [ ] CI の全ジョブ (setup, lint, test, build) が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)