### PR TITLE
test(commands): #186: 未テストコマンドの回帰テストを追加

### DIFF
--- a/src/commands/choiceCommand.spec.ts
+++ b/src/commands/choiceCommand.spec.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Logger } from '@slack/bolt';
+import { WebClient } from '@slack/web-api';
+import { ChoiceCommand } from './choiceCommand';
+import { SayFunction, SlackEvent } from './types';
+import * as randomUtils from '../utils/random';
+
+describe('ChoiceCommand', () => {
+  let command: ChoiceCommand;
+  let mockSay: SayFunction;
+  let mockLogger: Logger;
+  let mockEvent: SlackEvent;
+  let mockClient: WebClient;
+
+  beforeEach(() => {
+    command = new ChoiceCommand();
+    mockSay = vi.fn().mockResolvedValue({ ok: true, channel: 'C123', ts: '1.000' });
+    mockLogger = {
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
+      getLevel: vi.fn(),
+      setName: vi.fn(),
+    } as Logger;
+    mockEvent = {
+      type: 'message',
+      user: 'U123',
+      channel: 'C123',
+      channel_type: 'channel',
+      event_ts: '1.000',
+      ts: '1.000',
+      text: 'choice',
+    } as SlackEvent;
+    mockClient = {} as WebClient;
+    vi.restoreAllMocks();
+  });
+
+  it('選択結果を通常のチャンネルへ送信する', async () => {
+    vi.spyOn(randomUtils, 'getRandomItem').mockReturnValue('カレー');
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: ['ラーメン', 'カレー'],
+      invokedName: 'choice',
+      client: mockClient,
+    });
+
+    expect(mockSay).toHaveBeenCalledWith({ text: '選ばれたのは: *カレー*' });
+  });
+
+  it('選択肢がない場合はValidationErrorを送出する', async () => {
+    await expect(
+      command.execute({
+        event: mockEvent,
+        say: mockSay,
+        logger: mockLogger,
+        args: [],
+        invokedName: 'choice',
+        client: mockClient,
+      }),
+    ).rejects.toMatchObject({
+      message: 'No choices provided',
+      userMessage: '選択肢を指定してください。',
+      context: { argsLength: 0 },
+    });
+    expect(mockSay).not.toHaveBeenCalled();
+  });
+
+  it('乱数関数へ引数をそのまま渡す', async () => {
+    const getRandomItem = vi.spyOn(randomUtils, 'getRandomItem').mockReturnValue('寿司');
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: ['ラーメン', 'カレー', '寿司'],
+      invokedName: 'choice',
+      client: mockClient,
+    });
+
+    expect(getRandomItem).toHaveBeenCalledWith(['ラーメン', 'カレー', '寿司']);
+  });
+
+  it('既存スレッドへ返信する', async () => {
+    vi.spyOn(randomUtils, 'getRandomItem').mockReturnValue('ラーメン');
+
+    await command.execute({
+      event: { ...mockEvent, thread_ts: '0.999' },
+      say: mockSay,
+      logger: mockLogger,
+      args: ['ラーメン'],
+      invokedName: 'choice',
+      client: mockClient,
+    });
+
+    expect(mockSay).toHaveBeenCalledWith({ text: '選ばれたのは: *ラーメン*', thread_ts: '0.999' });
+  });
+});

--- a/src/commands/defaultCommand.spec.ts
+++ b/src/commands/defaultCommand.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Logger } from '@slack/bolt';
+import { WebClient } from '@slack/web-api';
+import { DefaultCommand } from './defaultCommand';
+import { SayFunction, SlackEvent } from './types';
+import * as randomUtils from '../utils/random';
+
+describe('DefaultCommand', () => {
+  let command: DefaultCommand;
+  let mockSay: SayFunction;
+  let mockLogger: Logger;
+  let mockEvent: SlackEvent;
+  let mockClient: WebClient;
+
+  beforeEach(() => {
+    command = new DefaultCommand();
+    mockSay = vi.fn().mockResolvedValue({ ok: true, channel: 'C123', ts: '1.000' });
+    mockLogger = {
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
+      getLevel: vi.fn(),
+      setName: vi.fn(),
+    } as Logger;
+    mockEvent = {
+      type: 'message',
+      user: 'U123',
+      channel: 'C123',
+      channel_type: 'channel',
+      event_ts: '1.000',
+      ts: '1.000',
+      text: 'unknown',
+    } as SlackEvent;
+    mockClient = {} as WebClient;
+    vi.restoreAllMocks();
+  });
+
+  it('選択結果を通常のチャンネルへ送信する', async () => {
+    vi.spyOn(randomUtils, 'getRandomItem').mockReturnValue('カレー');
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: ['ラーメン', 'カレー'],
+      invokedName: 'default',
+      client: mockClient,
+    });
+
+    expect(mockSay).toHaveBeenCalledWith({ text: '選ばれたのは: *カレー*' });
+  });
+
+  it('空入力ではヘルプ案内を送信する', async () => {
+    const getRandomItem = vi.spyOn(randomUtils, 'getRandomItem');
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: [],
+      invokedName: 'default',
+      client: mockClient,
+    });
+
+    expect(getRandomItem).not.toHaveBeenCalled();
+    expect(mockSay).toHaveBeenCalledWith({ text: "'help'コマンドでヘルプを表示できます。" });
+  });
+
+  it('空白を除いた選択肢を乱数関数へ渡す', async () => {
+    const getRandomItem = vi.spyOn(randomUtils, 'getRandomItem').mockReturnValue('寿司');
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: ['ラーメン', '', '寿司'],
+      invokedName: 'default',
+      client: mockClient,
+    });
+
+    expect(getRandomItem).toHaveBeenCalledWith(['ラーメン', '寿司']);
+  });
+
+  it('既存スレッドへ返信する', async () => {
+    vi.spyOn(randomUtils, 'getRandomItem').mockReturnValue('ラーメン');
+
+    await command.execute({
+      event: { ...mockEvent, thread_ts: '0.999' },
+      say: mockSay,
+      logger: mockLogger,
+      args: ['ラーメン'],
+      invokedName: 'default',
+      client: mockClient,
+    });
+
+    expect(mockSay).toHaveBeenCalledWith({ text: '選ばれたのは: *ラーメン*', thread_ts: '0.999' });
+  });
+});

--- a/src/commands/groupCommand.spec.ts
+++ b/src/commands/groupCommand.spec.ts
@@ -1,0 +1,274 @@
+import type { Logger } from '@slack/bolt';
+import type { WebClient } from '@slack/web-api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BOT_MENTION_NAME } from '../config/constants';
+import type { Group, GroupItem } from '../models/group';
+import { GroupService } from '../services/groupService';
+import { DatabaseError, ValidationError } from '../utils/errors';
+import { GroupCommand } from './groupCommand';
+import type { CommandContext, SayFunction, SlackEvent } from './types';
+
+vi.mock('../services/groupService', () => ({
+  GroupService: {
+    getAllGroups: vi.fn(),
+    createGroup: vi.fn(),
+    deleteGroup: vi.fn(),
+    getItemsByGroupName: vi.fn(),
+    addItemToGroup: vi.fn(),
+    addItemsToGroup: vi.fn(),
+    removeItemFromGroup: vi.fn(),
+    clearGroupItems: vi.fn(),
+  },
+}));
+
+const ts = '100.000';
+const threadTs = '99.000';
+
+function createContext(args: string[], eventThreadTs?: string): CommandContext {
+  const event = {
+    type: 'message',
+    user: 'U123',
+    channel: 'C123',
+    channel_type: 'channel',
+    event_ts: ts,
+    ts,
+    text: `group ${args.join(' ')}`,
+    ...(eventThreadTs === undefined ? {} : { thread_ts: eventThreadTs }),
+  } as SlackEvent;
+
+  return {
+    event,
+    say: vi.fn().mockResolvedValue({ ok: true }) as SayFunction,
+    logger: {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      setName: vi.fn(),
+      setLevel: vi.fn(),
+      getLevel: vi.fn(),
+    } as unknown as Logger,
+    args,
+    invokedName: 'group',
+    client: {} as WebClient,
+  };
+}
+
+async function execute(args: string[], eventThreadTs?: string): Promise<CommandContext> {
+  const context = createContext(args, eventThreadTs);
+  await new GroupCommand().execute(context);
+  return context;
+}
+
+function expectReply(context: CommandContext, text: string, expectedThreadTs = ts): void {
+  expect(context.say).toHaveBeenCalledWith({ text, thread_ts: expectedThreadTs });
+}
+
+describe('GroupCommand', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('ヘルプテキストにすべてのサブコマンドを含める', () => {
+    expect(new GroupCommand().getHelpText('group')).toBe(
+      '*group* - グループを管理します\n' +
+        `  - \`${BOT_MENTION_NAME} group list\` - すべてのグループを表示\n` +
+        `  - \`${BOT_MENTION_NAME} group create グループ名\` - 新しいグループを作成\n` +
+        `  - \`${BOT_MENTION_NAME} group delete グループ名\` - グループを削除\n` +
+        `  - \`${BOT_MENTION_NAME} group items グループ名\` - グループのアイテムを表示\n` +
+        `  - \`${BOT_MENTION_NAME} group add グループ名 アイテム...\` - アイテムを追加\n` +
+        `  - \`${BOT_MENTION_NAME} group remove グループ名 アイテム\` - アイテムを削除\n` +
+        `  - \`${BOT_MENTION_NAME} group clear グループ名\` - グループのすべてのアイテムを削除\n\n`,
+    );
+  });
+
+  it('サブコマンドなしと未知のサブコマンドに返信する', async () => {
+    expectReply(
+      await execute([]),
+      'サブコマンドを指定してください（list, create, delete, items, add, remove, clear）。',
+    );
+    expectReply(
+      await execute(['WHAT']),
+      '未知のサブコマンド: what\n有効なサブコマンド: list, create, delete, items, add, remove, clear',
+    );
+  });
+
+  it('listは空と一覧を応答し、スレッドTSを使う', async () => {
+    vi.mocked(GroupService.getAllGroups).mockReturnValue([]);
+    expectReply(await execute(['list'], threadTs), 'グループはありません。', threadTs);
+    vi.mocked(GroupService.getAllGroups).mockReturnValue([
+      { id: 1, name: '昼食', createdAt: '', updatedAt: '' } as Group,
+    ]);
+    expectReply(await execute(['list']), '*グループ一覧:*\n昼食');
+  });
+
+  it('listのserviceエラーはそのまま伝播する', async () => {
+    const error = new Error('list failed');
+    vi.mocked(GroupService.getAllGroups).mockImplementation(() => {
+      throw error;
+    });
+    await expect(new GroupCommand().execute(createContext(['list']))).rejects.toBe(error);
+  });
+
+  it('createは入力不足、成功、validation失敗を処理する', async () => {
+    expectReply(await execute(['create']), 'グループ名を指定してください。');
+    const context = await execute(['create', ' 昼食 ']);
+    expect(GroupService.createGroup).toHaveBeenCalledWith('昼食');
+    expectReply(context, 'グループ "昼食" を作成しました。');
+    await expect(new GroupCommand().execute(createContext(['create', ' ']))).rejects.toMatchObject({
+      name: 'ValidationError',
+      message: 'Empty group name',
+      userMessage: 'グループ名を入力してください',
+      context: { providedName: ' ' },
+    } satisfies Partial<ValidationError>);
+  });
+
+  it('createのserviceエラーはDatabaseErrorでラップする', async () => {
+    vi.mocked(GroupService.createGroup).mockImplementation(() => {
+      throw new Error('duplicate');
+    });
+    await expect(
+      new GroupCommand().execute(createContext(['create', '昼食'])),
+    ).rejects.toMatchObject({
+      name: 'DatabaseError',
+      message: 'Failed to create group',
+      userMessage:
+        'データベース操作中にエラーが発生しました。しばらく待ってから再試行してください。',
+      context: { groupName: '昼食', error: 'duplicate' },
+    } satisfies Partial<DatabaseError>);
+  });
+
+  it('deleteは入力不足、成功、対象なしを処理する', async () => {
+    expectReply(await execute(['delete']), 'グループ名を指定してください。');
+    vi.mocked(GroupService.deleteGroup).mockReturnValueOnce(true).mockReturnValueOnce(false);
+    expectReply(await execute(['delete', '昼食']), 'グループ "昼食" を削除しました。');
+    expectReply(await execute(['delete', 'なし']), 'グループ "なし" は存在しません。');
+  });
+
+  it('itemsは入力不足、空、一覧を処理する', async () => {
+    expectReply(await execute(['items']), 'グループ名を指定してください。');
+    vi.mocked(GroupService.getItemsByGroupName)
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ id: 1, groupId: 1, itemText: 'うどん', createdAt: '' } as GroupItem]);
+    expectReply(await execute(['items', '昼食']), 'グループ "昼食" にはアイテムがありません。');
+    expectReply(await execute(['items', '昼食']), '*グループ "昼食" のアイテム:*\nうどん');
+  });
+
+  it('addは入力不足、単一追加、対象なしを処理する', async () => {
+    expectReply(
+      await execute(['add', '昼食']),
+      'グループ名と1つ以上のアイテムを指定してください。複数のアイテムを一度に追加することもできます。',
+    );
+    vi.mocked(GroupService.addItemToGroup).mockReturnValueOnce(1).mockReturnValueOnce(undefined);
+    expectReply(
+      await execute(['add', '昼食', 'ラーメン']),
+      'グループ "昼食" にアイテム "ラーメン" を追加しました。',
+    );
+    expect(GroupService.addItemToGroup).toHaveBeenLastCalledWith('昼食', 'ラーメン');
+    expectReply(await execute(['add', 'なし', 'ラーメン']), 'グループ "なし" は存在しません。');
+  });
+
+  it('addは複数アイテムを空白で分割して一括追加する', async () => {
+    vi.mocked(GroupService.addItemsToGroup).mockReturnValue([1, 2]);
+    const context = await execute(['add', '昼食', 'ラーメン', 'うどん']);
+    expect(GroupService.addItemsToGroup).toHaveBeenCalledWith('昼食', ['ラーメン', 'うどん']);
+    expectReply(context, 'グループ "昼食" に 2 個のアイテムを追加しました：\nラーメン\nうどん');
+  });
+
+  it('複数アイテムの追加対象がない場合を案内する', async () => {
+    vi.mocked(GroupService.addItemsToGroup).mockReturnValue([]);
+
+    const context = await execute(['add', 'なし', 'ラーメン', 'うどん']);
+
+    expect(GroupService.addItemsToGroup).toHaveBeenCalledWith('なし', ['ラーメン', 'うどん']);
+    expectReply(context, 'グループ "なし" は存在しません。');
+  });
+
+  it('addのvalidation失敗とservice失敗は現行のエラー型で伝播する', async () => {
+    await expect(
+      new GroupCommand().execute(createContext(['add', '昼食', 'x'.repeat(201)])),
+    ).rejects.toMatchObject({
+      name: 'ValidationError',
+      replyMode: 'message-thread',
+      userMessage:
+        'アイテム "' + 'x'.repeat(201) + '" のバリデーションエラー: Item text too long: 201 chars',
+    });
+    vi.mocked(GroupService.addItemToGroup).mockImplementation(() => {
+      throw new Error('db down');
+    });
+    await expect(
+      new GroupCommand().execute(createContext(['add', '昼食', 'ラーメン'])),
+    ).rejects.toMatchObject({
+      name: 'DatabaseError',
+      message: 'Failed to add group items',
+      userMessage: 'アイテムの追加に失敗しました: db down',
+      context: {
+        groupName: '昼食',
+        items: ['ラーメン'],
+        error: 'db down',
+      },
+      replyMode: 'message-thread',
+    });
+  });
+
+  it('removeは入力不足、成功、対象なしを処理する', async () => {
+    expectReply(await execute(['remove', '昼食']), 'グループ名とアイテムを指定してください。');
+    vi.mocked(GroupService.removeItemFromGroup)
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+    expectReply(
+      await execute(['remove', '昼食', '焼き', 'そば']),
+      'グループ "昼食" からアイテム "焼き そば" を削除しました。',
+    );
+    expect(GroupService.removeItemFromGroup).toHaveBeenLastCalledWith('昼食', '焼き そば');
+    expectReply(
+      await execute(['remove', '昼食', 'なし']),
+      'グループ "昼食" またはアイテム "なし" は存在しません。',
+    );
+  });
+
+  it('clearは入力不足、成功、対象なしを処理する', async () => {
+    expectReply(await execute(['clear']), 'グループ名を指定してください。');
+    vi.mocked(GroupService.clearGroupItems).mockReturnValueOnce(true).mockReturnValueOnce(false);
+    expectReply(
+      await execute(['clear', '昼食']),
+      'グループ "昼食" のすべてのアイテムを削除しました。',
+    );
+    expectReply(await execute(['clear', 'なし']), 'グループ "なし" は存在しません。');
+  });
+
+  it('deleteのserviceエラーはラップせずそのまま伝播する', async () => {
+    const error = new Error('delete failed');
+    vi.mocked(GroupService.deleteGroup).mockImplementation(() => {
+      throw error;
+    });
+    await expect(new GroupCommand().execute(createContext(['delete', '昼食']))).rejects.toBe(error);
+  });
+
+  it('itemsのserviceエラーはラップせずそのまま伝播する', async () => {
+    const error = new Error('items failed');
+    vi.mocked(GroupService.getItemsByGroupName).mockImplementation(() => {
+      throw error;
+    });
+
+    await expect(new GroupCommand().execute(createContext(['items', '昼食']))).rejects.toBe(error);
+  });
+
+  it('removeのserviceエラーはラップせずそのまま伝播する', async () => {
+    const error = new Error('remove failed');
+    vi.mocked(GroupService.removeItemFromGroup).mockImplementation(() => {
+      throw error;
+    });
+
+    await expect(
+      new GroupCommand().execute(createContext(['remove', '昼食', 'ラーメン'])),
+    ).rejects.toBe(error);
+  });
+
+  it('clearのserviceエラーはラップせずそのまま伝播する', async () => {
+    const error = new Error('clear failed');
+    vi.mocked(GroupService.clearGroupItems).mockImplementation(() => {
+      throw error;
+    });
+
+    await expect(new GroupCommand().execute(createContext(['clear', '昼食']))).rejects.toBe(error);
+  });
+});

--- a/src/commands/groupShuffleCommand.spec.ts
+++ b/src/commands/groupShuffleCommand.spec.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Logger } from '@slack/bolt';
+import { WebClient } from '@slack/web-api';
+import { GroupShuffleCommand } from './groupShuffleCommand';
+import { SayFunction, SlackEvent } from './types';
+import { GroupService } from '../services/groupService';
+import { GroupItem } from '../models/group';
+import * as randomUtils from '../utils/random';
+
+vi.mock('../services/groupService', () => ({ GroupService: { getItemsByGroupName: vi.fn() } }));
+
+describe('GroupShuffleCommand', () => {
+  let command: GroupShuffleCommand;
+  let mockSay: SayFunction;
+  let mockLogger: Logger;
+  let mockEvent: SlackEvent;
+  let mockClient: WebClient;
+
+  beforeEach(() => {
+    command = new GroupShuffleCommand();
+    mockSay = vi.fn().mockResolvedValue({ ok: true, channel: 'C123', ts: '1.000' });
+    mockLogger = {
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
+      getLevel: vi.fn(),
+      setName: vi.fn(),
+    } as Logger;
+    mockEvent = {
+      type: 'message',
+      user: 'U123',
+      channel: 'C123',
+      channel_type: 'channel',
+      event_ts: '1.000',
+      ts: '1.000',
+      text: 'groupshuffle',
+    } as SlackEvent;
+    mockClient = {} as WebClient;
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('グループ名がない場合は不足メッセージを送信する', async () => {
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: [],
+      invokedName: 'groupshuffle',
+      client: mockClient,
+    });
+
+    expect(GroupService.getItemsByGroupName).not.toHaveBeenCalled();
+    expect(mockSay).toHaveBeenCalledWith({ text: 'グループ名を指定してください。' });
+  });
+
+  it.each(['存在しないグループ', '空グループ'])(
+    '%s が存在しないか空の場合は同じメッセージを送信する',
+    async (groupName) => {
+      vi.mocked(GroupService.getItemsByGroupName).mockReturnValue([]);
+
+      await command.execute({
+        event: mockEvent,
+        say: mockSay,
+        logger: mockLogger,
+        args: [groupName],
+        invokedName: 'groupshuffle',
+        client: mockClient,
+      });
+
+      expect(GroupService.getItemsByGroupName).toHaveBeenCalledWith(groupName);
+      expect(mockSay).toHaveBeenCalledWith({
+        text: `グループ "${groupName}" は存在しないか、アイテムがありません。`,
+      });
+    },
+  );
+
+  it('アイテムが1件の場合は特別なメッセージを送信する', async () => {
+    vi.mocked(GroupService.getItemsByGroupName).mockReturnValue([item('唯一')]);
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: ['テスト'],
+      invokedName: 'groupshuffle',
+      client: mockClient,
+    });
+
+    expect(mockSay).toHaveBeenCalledWith({
+      text: 'グループ "テスト" にはアイテムが1つしかありません: *唯一*',
+    });
+  });
+
+  it('GroupServiceのアイテムをシャッフルして番号付きで送信する', async () => {
+    vi.mocked(GroupService.getItemsByGroupName).mockReturnValue([item('A'), item('B'), item('C')]);
+    const shuffleArray = vi.spyOn(randomUtils, 'shuffleArray').mockReturnValue(['C', 'A', 'B']);
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: ['テスト'],
+      invokedName: 'groupshuffle',
+      client: mockClient,
+    });
+
+    expect(GroupService.getItemsByGroupName).toHaveBeenCalledWith('テスト');
+    expect(shuffleArray).toHaveBeenCalledWith(['A', 'B', 'C']);
+    expect(mockSay).toHaveBeenCalledWith({
+      text: 'グループ "テスト" のシャッフル結果:\n1. C\n2. A\n3. B',
+    });
+  });
+
+  it('既存スレッドへ返信する', async () => {
+    vi.mocked(GroupService.getItemsByGroupName).mockReturnValue([item('A'), item('B')]);
+    vi.spyOn(randomUtils, 'shuffleArray').mockReturnValue(['B', 'A']);
+
+    await command.execute({
+      event: { ...mockEvent, thread_ts: '0.999' },
+      say: mockSay,
+      logger: mockLogger,
+      args: ['テスト'],
+      invokedName: 'groupshuffle',
+      client: mockClient,
+    });
+
+    expect(mockSay).toHaveBeenCalledWith({
+      text: 'グループ "テスト" のシャッフル結果:\n1. B\n2. A',
+      thread_ts: '0.999',
+    });
+  });
+});
+
+const item = (itemText: string): GroupItem => ({
+  id: 1,
+  groupId: 1,
+  itemText,
+  createdAt: '2026-01-01T00:00:00.000Z',
+});

--- a/src/commands/reactionCommand.spec.ts
+++ b/src/commands/reactionCommand.spec.ts
@@ -1,0 +1,295 @@
+import type { Logger } from '@slack/bolt';
+import type { WebClient } from '@slack/web-api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BOT_MENTION_NAME } from '../config/constants';
+import type { ReactionMapping } from '../models/reactionMapping';
+import { ReactionService } from '../services/reactionService';
+import { ReactionCommand } from './reactionCommand';
+import type { CommandContext, SayFunction, SlackEvent } from './types';
+
+vi.mock('../services/reactionService', () => ({
+  ReactionService: {
+    addReactionMapping: vi.fn(),
+    removeReactionMapping: vi.fn(),
+    getAllReactionMappings: vi.fn(),
+  },
+}));
+
+function createContext(
+  args: string[],
+  eventOverrides: Partial<SlackEvent> = {},
+): {
+  context: CommandContext;
+  say: ReturnType<typeof vi.fn>;
+  uploadV2: ReturnType<typeof vi.fn>;
+} {
+  const event = {
+    type: 'message',
+    user: 'U123',
+    channel: 'C123',
+    channel_type: 'channel',
+    event_ts: '100.000',
+    ts: '100.000',
+    text: `reaction ${args.join(' ')}`,
+    ...eventOverrides,
+  } as SlackEvent;
+  const say = vi.fn().mockResolvedValue({ ok: true });
+  const uploadV2 = vi.fn().mockResolvedValue({ ok: true });
+
+  return {
+    context: {
+      event,
+      say: say as SayFunction,
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        setName: vi.fn(),
+        setLevel: vi.fn(),
+        getLevel: vi.fn(),
+      } as unknown as Logger,
+      args,
+      invokedName: 'reaction',
+      client: {
+        files: {
+          uploadV2,
+        },
+      } as unknown as WebClient,
+    },
+    say,
+    uploadV2,
+  };
+}
+
+const mapping = (overrides: Partial<ReactionMapping> = {}): ReactionMapping => ({
+  id: 1,
+  triggerText: 'hello',
+  reaction: ':wave:',
+  usageCount: 2,
+  createdAt: '2026-01-01 00:00:00',
+  updatedAt: '2026-01-02 00:00:00',
+  ...overrides,
+});
+
+describe('ReactionCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('コマンド情報とヘルプを返す', () => {
+    const command = new ReactionCommand();
+
+    expect(command.description).toBe(
+      'リアクションマッピングを管理します（チャンネルメッセージに自動的にリアクションを追加）',
+    );
+    expect(command.getExamples('reaction')).toEqual([
+      `${BOT_MENTION_NAME} reaction export`,
+      `${BOT_MENTION_NAME} reaction add トリガー :emoji:`,
+      `${BOT_MENTION_NAME} reaction remove トリガー :emoji:`,
+    ]);
+    expect(command.getHelpText('reaction')).toBe(
+      `*reaction* - ${command.description}\n` +
+        `  - \`${BOT_MENTION_NAME} reaction export\` - すべてのリアクションマッピングをCSV形式でエクスポート\n` +
+        `  - \`${BOT_MENTION_NAME} reaction add トリガー :emoji:\` - リアクションマッピングを追加\n` +
+        `  - \`${BOT_MENTION_NAME} reaction remove トリガー :emoji:\` - リアクションマッピングを削除\n\n`,
+    );
+  });
+
+  it('サブコマンドがない場合は元メッセージのスレッドへ案内する', async () => {
+    const { context, say } = createContext([]);
+
+    await new ReactionCommand().execute(context);
+
+    expect(say).toHaveBeenCalledWith({
+      text: 'サブコマンドを指定してください（export, add, remove）。',
+      thread_ts: '100.000',
+    });
+  });
+
+  it('未知のサブコマンドを小文字化して既存スレッドへ案内する', async () => {
+    const { context, say } = createContext(['UNKNOWN'], { thread_ts: '90.000' });
+
+    await new ReactionCommand().execute(context);
+
+    expect(say).toHaveBeenCalledWith({
+      text: '未知のサブコマンド: unknown\n有効なサブコマンド: export, add, remove',
+      thread_ts: '90.000',
+    });
+  });
+
+  it.each(['add', 'remove'])('%sの引数が不足している場合は案内する', async (subCommand) => {
+    const { context, say } = createContext([subCommand, 'trigger']);
+
+    await new ReactionCommand().execute(context);
+
+    expect(say).toHaveBeenCalledWith({
+      text: 'トリガーテキストとリアクションを指定してください。',
+      thread_ts: '100.000',
+    });
+    expect(ReactionService.addReactionMapping).not.toHaveBeenCalled();
+    expect(ReactionService.removeReactionMapping).not.toHaveBeenCalled();
+  });
+
+  it('検証済みトリガーでマッピングを追加する', async () => {
+    vi.mocked(ReactionService.addReactionMapping).mockReturnValue(1);
+    const { context, say } = createContext(['add', ' hello ', ':wave:']);
+
+    await new ReactionCommand().execute(context);
+
+    expect(ReactionService.addReactionMapping).toHaveBeenCalledWith('hello', ':wave:');
+    expect(say).toHaveBeenCalledWith({
+      text: 'リアクションマッピングを追加しました: "hello" → :wave:',
+      thread_ts: '100.000',
+    });
+  });
+
+  it('addの検証失敗をスレッド返信用ValidationErrorへ変換する', async () => {
+    const { context, say } = createContext(['add', '', ':wave:']);
+
+    await expect(new ReactionCommand().execute(context)).rejects.toMatchObject({
+      name: 'ValidationError',
+      message: 'Empty trigger text',
+      userMessage: 'バリデーションエラー: Empty trigger text',
+      context: { providedText: '' },
+      replyMode: 'message-thread',
+    });
+    expect(ReactionService.addReactionMapping).not.toHaveBeenCalled();
+    expect(say).not.toHaveBeenCalled();
+  });
+
+  it('addのDB失敗をスレッド返信用DatabaseErrorへ変換する', async () => {
+    vi.mocked(ReactionService.addReactionMapping).mockImplementation(() => {
+      throw new Error('db down');
+    });
+    const { context, say } = createContext(['add', 'hello', ':wave:']);
+
+    await expect(new ReactionCommand().execute(context)).rejects.toMatchObject({
+      name: 'DatabaseError',
+      message: 'Failed to add reaction mapping',
+      userMessage: 'リアクションマッピングの追加に失敗しました: db down',
+      context: {
+        triggerText: 'hello',
+        reaction: ':wave:',
+        error: 'db down',
+      },
+      replyMode: 'message-thread',
+    });
+    expect(say).not.toHaveBeenCalled();
+  });
+
+  it('存在するマッピングを削除する', async () => {
+    vi.mocked(ReactionService.removeReactionMapping).mockReturnValue(true);
+    const { context, say } = createContext(['remove', 'hello', ':wave:']);
+
+    await new ReactionCommand().execute(context);
+
+    expect(ReactionService.removeReactionMapping).toHaveBeenCalledWith('hello', ':wave:');
+    expect(say).toHaveBeenCalledWith({
+      text: 'リアクションマッピングを削除しました: "hello" → :wave:',
+      thread_ts: '100.000',
+    });
+  });
+
+  it('存在しないマッピングの削除を案内する', async () => {
+    vi.mocked(ReactionService.removeReactionMapping).mockReturnValue(false);
+    const { context, say } = createContext(['remove', 'missing', ':eyes:']);
+
+    await new ReactionCommand().execute(context);
+
+    expect(say).toHaveBeenCalledWith({
+      text: 'リアクションマッピング "missing" → :eyes: は存在しません。',
+      thread_ts: '100.000',
+    });
+  });
+
+  it('removeのDB失敗は現在のサービスエラーをそのまま伝播する', async () => {
+    vi.mocked(ReactionService.removeReactionMapping).mockImplementation(() => {
+      throw new Error('db down');
+    });
+    const { context, say } = createContext(['remove', 'hello', ':wave:']);
+
+    await expect(new ReactionCommand().execute(context)).rejects.toThrow('db down');
+    expect(say).not.toHaveBeenCalled();
+  });
+
+  it('マッピングが0件の場合はファイルをアップロードせず案内する', async () => {
+    vi.mocked(ReactionService.getAllReactionMappings).mockReturnValue([]);
+    const { context, say, uploadV2 } = createContext(['export']);
+
+    await new ReactionCommand().execute(context);
+
+    expect(ReactionService.getAllReactionMappings).toHaveBeenCalledOnce();
+    expect(uploadV2).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith({
+      text: 'エクスポートするリアクションマッピングはありません。',
+      thread_ts: '100.000',
+    });
+  });
+
+  it('CSVを日時付きファイル名で既存スレッドへアップロードする', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-25T01:02:03.456Z'));
+    vi.mocked(ReactionService.getAllReactionMappings).mockReturnValue([
+      mapping({ triggerText: 'hello,world' }),
+    ]);
+    const { context, say, uploadV2 } = createContext(['export'], { thread_ts: '90.000' });
+
+    await new ReactionCommand().execute(context);
+
+    const csv =
+      'ID,トリガーテキスト,リアクション,使用回数,作成日時,更新日時\n' +
+      '1,"hello,world",:wave:,2,2026-01-01 00:00:00,2026-01-02 00:00:00\n';
+    expect(uploadV2).toHaveBeenCalledWith({
+      channel_id: 'C123',
+      initial_comment: 'リアクションマッピングをCSVファイルとしてエクスポートしました。',
+      file_uploads: [
+        {
+          file: Buffer.from(csv, 'utf-8'),
+          filename: 'reaction-mappings-2026-07-25T01-02-03-456Z.csv',
+          title: 'リアクションマッピング一覧',
+        },
+      ],
+      thread_ts: '90.000',
+    });
+    expect(say).not.toHaveBeenCalled();
+  });
+
+  it('チャンネル直下のexportも元メッセージのtsをアップロード先スレッドにする', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-25T01:02:03.456Z'));
+    vi.mocked(ReactionService.getAllReactionMappings).mockReturnValue([mapping()]);
+    const { context, uploadV2 } = createContext(['export']);
+
+    await new ReactionCommand().execute(context);
+
+    expect(uploadV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel_id: 'C123',
+        thread_ts: '100.000',
+      }),
+    );
+  });
+
+  it('アップロード失敗をスレッド返信用SlackAPIErrorへ変換する', async () => {
+    vi.mocked(ReactionService.getAllReactionMappings).mockReturnValue([mapping()]);
+    const { context, say, uploadV2 } = createContext(['export']);
+    uploadV2.mockRejectedValue(new Error('slack down'));
+
+    await expect(new ReactionCommand().execute(context)).rejects.toMatchObject({
+      name: 'SlackAPIError',
+      message: 'Failed to export reaction mappings',
+      userMessage: 'リアクションマッピングのエクスポートに失敗しました: slack down',
+      context: {
+        channel: 'C123',
+        error: 'slack down',
+      },
+      replyMode: 'message-thread',
+    });
+    expect(say).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/secretCommand.spec.ts
+++ b/src/commands/secretCommand.spec.ts
@@ -1,0 +1,114 @@
+import type { Logger } from '@slack/bolt';
+import type { WebClient } from '@slack/web-api';
+import type { GenericMessageEvent } from '@slack/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as randomUtils from '../utils/random';
+import { SecretCommand } from './secretCommand';
+import type { CommandContext, SayFunction } from './types';
+
+const createContext = (args: string[], event: GenericMessageEvent): CommandContext => ({
+  event,
+  say: vi.fn().mockResolvedValue({ ok: true }) as SayFunction,
+  logger: {} as Logger,
+  args,
+  invokedName: 'secret',
+  client: {} as WebClient,
+});
+
+const createEvent = (threadTs?: string): GenericMessageEvent => ({
+  type: 'message',
+  subtype: undefined,
+  user: 'U123',
+  channel: 'C123',
+  channel_type: 'channel',
+  event_ts: '100.000',
+  ts: '100.000',
+  text: 'secret',
+  ...(threadTs && { thread_ts: threadTs }),
+});
+
+describe('SecretCommand', () => {
+  let command: SecretCommand;
+
+  beforeEach(() => {
+    command = new SecretCommand();
+    vi.spyOn(randomUtils, 'getRandomStringWithSymbols').mockReturnValue('aB!2');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('引数なしでは既定の10文字を生成して通常メッセージに返信する', async () => {
+    const context = createContext([], createEvent());
+
+    await command.execute(context);
+
+    expect(randomUtils.getRandomStringWithSymbols).toHaveBeenCalledWith(10);
+    expect(context.say).toHaveBeenCalledWith({
+      text: '🔐 生成されたシークレット文字列（記号含む）: `aB!2`',
+    });
+  });
+
+  it('指定した長さを生成する', async () => {
+    const context = createContext(['25'], createEvent());
+
+    await command.execute(context);
+
+    expect(randomUtils.getRandomStringWithSymbols).toHaveBeenCalledWith(25);
+  });
+
+  it('100を超える指定は100文字に制限する', async () => {
+    const context = createContext(['101'], createEvent());
+
+    await command.execute(context);
+
+    expect(randomUtils.getRandomStringWithSymbols).toHaveBeenCalledWith(100);
+  });
+
+  it.each(['text', '0', '-1'])('不正な長さ %s はValidationErrorにする', async (value) => {
+    const context = createContext([value], createEvent());
+
+    await expect(command.execute(context)).rejects.toMatchObject({
+      message: `Invalid secret length: ${value}`,
+      userMessage: '有効な正の整数を指定してください。',
+      context: { providedValue: value },
+    });
+    expect(randomUtils.getRandomStringWithSymbols).not.toHaveBeenCalled();
+    expect(context.say).not.toHaveBeenCalled();
+  });
+
+  it('parseIntで解釈できる先頭の整数を長さとして使う', async () => {
+    const context = createContext(['12abc'], createEvent());
+
+    await command.execute(context);
+
+    expect(randomUtils.getRandomStringWithSymbols).toHaveBeenCalledWith(12);
+  });
+
+  it('生成に失敗すると原因をcontextに含むBotErrorを送出する', async () => {
+    vi.mocked(randomUtils.getRandomStringWithSymbols).mockImplementation(() => {
+      throw new Error('random source unavailable');
+    });
+    const context = createContext([], createEvent());
+
+    await expect(command.execute(context)).rejects.toMatchObject({
+      name: 'BotError',
+      message: 'Failed to generate secret string',
+      userMessage: 'ランダム文字列の生成中にエラーが発生しました。',
+      context: { error: 'random source unavailable' },
+    });
+    expect(context.say).not.toHaveBeenCalled();
+  });
+
+  it('既存スレッドではスレッドに返信する', async () => {
+    const context = createContext([], createEvent('99.000'));
+
+    await command.execute(context);
+
+    expect(context.say).toHaveBeenCalledWith({
+      text: '🔐 生成されたシークレット文字列（記号含む）: `aB!2`',
+      thread_ts: '99.000',
+    });
+  });
+});

--- a/src/commands/shuffleCommand.spec.ts
+++ b/src/commands/shuffleCommand.spec.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Logger } from '@slack/bolt';
+import { WebClient } from '@slack/web-api';
+import { BOT_MENTION_NAME } from '../config/constants';
+import { ShuffleCommand } from './shuffleCommand';
+import { SayFunction, SlackEvent } from './types';
+import * as randomUtils from '../utils/random';
+
+describe('ShuffleCommand', () => {
+  let command: ShuffleCommand;
+  let mockSay: SayFunction;
+  let mockLogger: Logger;
+  let mockEvent: SlackEvent;
+  let mockClient: WebClient;
+  const insufficientItemsMessage = `並び替える項目を2つ以上指定してください。\n例: \`${BOT_MENTION_NAME} shuffle A B C D\``;
+
+  beforeEach(() => {
+    command = new ShuffleCommand();
+    mockSay = vi.fn().mockResolvedValue({ ok: true, channel: 'C123', ts: '1.000' });
+    mockLogger = {
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
+      getLevel: vi.fn(),
+      setName: vi.fn(),
+    } as Logger;
+    mockEvent = {
+      type: 'message',
+      user: 'U123',
+      channel: 'C123',
+      channel_type: 'channel',
+      event_ts: '1.000',
+      ts: '1.000',
+      text: 'shuffle',
+    } as SlackEvent;
+    mockClient = {} as WebClient;
+    vi.restoreAllMocks();
+  });
+
+  it.each([[[]], [['A']]])('引数が%jの場合は不足メッセージを送信する', async (args) => {
+    const shuffleArray = vi.spyOn(randomUtils, 'shuffleArray');
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args,
+      invokedName: 'shuffle',
+      client: mockClient,
+    });
+
+    expect(shuffleArray).not.toHaveBeenCalled();
+    expect(mockSay).toHaveBeenCalledWith({ text: insufficientItemsMessage });
+  });
+
+  it('複数の結果を番号付きで通常のチャンネルへ送信する', async () => {
+    vi.spyOn(randomUtils, 'shuffleArray').mockReturnValue(['C', 'A', 'B']);
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: ['A', 'B', 'C'],
+      invokedName: 'shuffle',
+      client: mockClient,
+    });
+
+    expect(mockSay).toHaveBeenCalledWith({ text: 'シャッフル結果:\n1. C\n2. A\n3. B' });
+  });
+
+  it('乱数関数へ引数をそのまま渡す', async () => {
+    const shuffleArray = vi.spyOn(randomUtils, 'shuffleArray').mockReturnValue(['B', 'A']);
+
+    await command.execute({
+      event: mockEvent,
+      say: mockSay,
+      logger: mockLogger,
+      args: ['A', 'B'],
+      invokedName: 'shuffle',
+      client: mockClient,
+    });
+
+    expect(shuffleArray).toHaveBeenCalledWith(['A', 'B']);
+  });
+
+  it('既存スレッドへ返信する', async () => {
+    vi.spyOn(randomUtils, 'shuffleArray').mockReturnValue(['B', 'A']);
+
+    await command.execute({
+      event: { ...mockEvent, thread_ts: '0.999' },
+      say: mockSay,
+      logger: mockLogger,
+      args: ['A', 'B'],
+      invokedName: 'shuffle',
+      client: mockClient,
+    });
+
+    expect(mockSay).toHaveBeenCalledWith({
+      text: 'シャッフル結果:\n1. B\n2. A',
+      thread_ts: '0.999',
+    });
+  });
+});

--- a/src/commands/zakoSecretCommand.spec.ts
+++ b/src/commands/zakoSecretCommand.spec.ts
@@ -1,0 +1,114 @@
+import type { Logger } from '@slack/bolt';
+import type { WebClient } from '@slack/web-api';
+import type { GenericMessageEvent } from '@slack/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as randomUtils from '../utils/random';
+import type { CommandContext, SayFunction } from './types';
+import { ZakoSecretCommand } from './zakoSecretCommand';
+
+const createContext = (args: string[], event: GenericMessageEvent): CommandContext => ({
+  event,
+  say: vi.fn().mockResolvedValue({ ok: true }) as SayFunction,
+  logger: {} as Logger,
+  args,
+  invokedName: 'zako-secret',
+  client: {} as WebClient,
+});
+
+const createEvent = (threadTs?: string): GenericMessageEvent => ({
+  type: 'message',
+  subtype: undefined,
+  user: 'U123',
+  channel: 'C123',
+  channel_type: 'channel',
+  event_ts: '100.000',
+  ts: '100.000',
+  text: 'zako-secret',
+  ...(threadTs && { thread_ts: threadTs }),
+});
+
+describe('ZakoSecretCommand', () => {
+  let command: ZakoSecretCommand;
+
+  beforeEach(() => {
+    command = new ZakoSecretCommand();
+    vi.spyOn(randomUtils, 'getRandomString').mockReturnValue('ab12');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('引数なしでは既定の10文字を生成して通常メッセージに返信する', async () => {
+    const context = createContext([], createEvent());
+
+    await command.execute(context);
+
+    expect(randomUtils.getRandomString).toHaveBeenCalledWith(10);
+    expect(context.say).toHaveBeenCalledWith({
+      text: '🔑 生成されたシークレット文字列: `ab12`',
+    });
+  });
+
+  it('指定した長さを生成する', async () => {
+    const context = createContext(['25'], createEvent());
+
+    await command.execute(context);
+
+    expect(randomUtils.getRandomString).toHaveBeenCalledWith(25);
+  });
+
+  it('100を超える指定は100文字に制限する', async () => {
+    const context = createContext(['101'], createEvent());
+
+    await command.execute(context);
+
+    expect(randomUtils.getRandomString).toHaveBeenCalledWith(100);
+  });
+
+  it.each(['text', '0', '-1'])('不正な長さ %s はValidationErrorにする', async (value) => {
+    const context = createContext([value], createEvent());
+
+    await expect(command.execute(context)).rejects.toMatchObject({
+      message: `Invalid secret length: ${value}`,
+      userMessage: '有効な正の整数を指定してください。',
+      context: { providedValue: value },
+    });
+    expect(randomUtils.getRandomString).not.toHaveBeenCalled();
+    expect(context.say).not.toHaveBeenCalled();
+  });
+
+  it('parseIntで解釈できる先頭の整数を長さとして使う', async () => {
+    const context = createContext(['12abc'], createEvent());
+
+    await command.execute(context);
+
+    expect(randomUtils.getRandomString).toHaveBeenCalledWith(12);
+  });
+
+  it('生成に失敗すると原因をcontextに含むBotErrorを送出する', async () => {
+    vi.mocked(randomUtils.getRandomString).mockImplementation(() => {
+      throw new Error('random source unavailable');
+    });
+    const context = createContext([], createEvent());
+
+    await expect(command.execute(context)).rejects.toMatchObject({
+      name: 'BotError',
+      message: 'Failed to generate random string',
+      userMessage: 'ランダム文字列の生成中にエラーが発生しました。',
+      context: { error: 'random source unavailable' },
+    });
+    expect(context.say).not.toHaveBeenCalled();
+  });
+
+  it('既存スレッドではスレッドに返信する', async () => {
+    const context = createContext([], createEvent('99.000'));
+
+    await command.execute(context);
+
+    expect(context.say).toHaveBeenCalledWith({
+      text: '🔑 生成されたシークレット文字列: `ab12`',
+      thread_ts: '99.000',
+    });
+  });
+});

--- a/src/services/reactionService.spec.ts
+++ b/src/services/reactionService.spec.ts
@@ -54,4 +54,36 @@ describe('ReactionService.findMatchingMappings', () => {
 
     expect(ReactionService.findMatchingMappings('goodbye')).toEqual([]);
   });
+
+  it('addReactionMappingは作成データをModelへ渡し戻り値を返す', () => {
+    vi.mocked(ReactionMappingModel.create).mockReturnValue(42);
+
+    expect(ReactionService.addReactionMapping('hello', ':wave:')).toBe(42);
+    expect(ReactionMappingModel.create).toHaveBeenCalledWith({
+      triggerText: 'hello',
+      reaction: ':wave:',
+    });
+  });
+
+  it('removeReactionMappingは引数をModelへ渡し戻り値を返す', () => {
+    vi.mocked(ReactionMappingModel.deleteByTriggerAndReaction).mockReturnValue(true);
+
+    expect(ReactionService.removeReactionMapping('hello', ':wave:')).toBe(true);
+    expect(ReactionMappingModel.deleteByTriggerAndReaction).toHaveBeenCalledWith('hello', ':wave:');
+  });
+
+  it('getAllReactionMappingsはModelの戻り値をそのまま返す', () => {
+    const mappings = [mapping(1, 'hello', ':wave:')];
+    vi.mocked(ReactionMappingModel.getAll).mockReturnValue(mappings);
+
+    expect(ReactionService.getAllReactionMappings()).toBe(mappings);
+    expect(ReactionMappingModel.getAll).toHaveBeenCalledWith();
+  });
+
+  it('incrementReactionUsageは引数をModelへ渡し戻り値を返す', () => {
+    vi.mocked(ReactionMappingModel.incrementUsageCount).mockReturnValue(false);
+
+    expect(ReactionService.incrementReactionUsage('hello', ':wave:')).toBe(false);
+    expect(ReactionMappingModel.incrementUsageCount).toHaveBeenCalledWith('hello', ':wave:');
+  });
 });


### PR DESCRIPTION
## Implementation Summary

Issue #186として、未テストだった8コマンドとReactionServiceの残る操作へ回帰テストを追加しました。

- Choice／Defaultの選択結果、空入力、乱数呼び出し、スレッド返信を検証
- Shuffle／GroupShuffleの入力不足、空・単一・複数要素、番号付き結果を検証
- Secret／ZakoSecretの既定長、上限、不正値、生成失敗を検証
- Groupの全サブコマンドについて、成功、対象なし、入力不足、検証失敗、サービス失敗を検証
- Reactionの追加・削除・CSVエクスポートとSlack APIエラーを検証
- ReactionServiceからModelへの引数と戻り値の委譲を検証

プロダクション挙動は変更していません。テストは177件から251件へ増加しました。

## Decisions

- 現在の挙動に不自然な点があっても修正せず、回帰テストとして固定しました。挙動修正とテスト拡充を分離し、変更範囲をIssue #186内に限定するためです。
- 乱数、GroupService、ReactionService、Slack WebClientを境界でモックしました。コマンド自身の応答と副作用を決定的に検証するためです。
- CommandContextの生成は各spec内の小さなヘルパーに留めました。テスト追加のための共通モジュールやプロダクションコードを増やさないためです。
- E2E、カバレッジ閾値、DI、README／CLAUDE.mdは変更対象外としました。

## Notes

### 固定した現行挙動

- Secret系では `12abc` が `parseInt` により長さ12として受理される
- Group addの検証エラーには内部向け英語文言が含まれる
- 一部のGroup／Reaction操作ではサービスエラーがラップされず、そのまま伝播する
- GroupShuffleは存在しないグループと空グループを区別しない
- Group／Reactionのチャンネル直下応答やexportでは、元メッセージの `event.ts` がスレッドTSとして使われる