### PR TITLE
#55: 依存関係の組み立て構成を更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,11 @@ npx vitest run src/path/to/file.spec.ts
 
 ### Application Flow
 
-1. **Entry Point** (`src/index.ts`): DB接続後にRepository、Service、Command、Handlerを組み立て、Boltアプリケーションを起動する
-2. **App Configuration** (`src/app.ts`): Creates and configures the Bolt app instance with Socket Mode or HTTP mode based on `SLACK_SOCKET_MODE` environment variable
-3. **Event Handlers**: Two main handler types registered at startup:
+1. **Entry Point** (`src/index.ts`): `.env`を読み込み、起動設定、Slack App、DB接続、Application Runtimeを生成し、プロセスシグナルを処理する
+2. **App Configuration** (`src/config/appConfig.ts`): 環境変数を副作用のない起動設定へ変換する
+3. **Slack App Factory** (`src/app.ts`): 起動設定とLoggerからBolt Appを生成する
+4. **Application Runtime** (`src/runtime.ts`): Repository、Service、Command、Handlerを組み立て、起動とDB接続の終了を管理する
+5. **Event Handlers**: Two main handler types registered at startup:
    - `mentionHandler`: Processes `app_mention` events
    - `messageHandler`: Handles all message events for DMs (processes as commands) and channel messages (applies automatic reactions)
 
@@ -54,11 +56,11 @@ Commands follow a class-based pattern implementing the `Command` interface (`src
 
 - **SQLite** via `better-sqlite3` for persistence
 - **Database file**: `data/trrbot.db` (auto-created on first run)
-- **Connection and schema** (`src/db/`): 起動時に共有接続を明示的に開き、スキーマを初期化する
+- **Connection and schema** (`src/db/`): 呼び出しごとに独立した接続を開き、Application Runtimeが所有する接続のスキーマを初期化する
 - **Models** (`src/models/`): `Group`、`GroupItem`、`ReactionMapping`などのデータ型を定義する
 - **Repositories** (`src/repositories/`): 注入されたSQLite接続を使ってSQLとトランザクションを実行する
 - **Services** (`src/services/`): 注入されたRepositoryを使ってGroup / Reactionのユースケースを実行する
-- **Composition root** (`src/index.ts`): RepositoryとServiceを1回だけ生成し、Command registry、router、Handlerへ渡す
+- **Composition root** (`src/runtime.ts`): RepositoryとServiceを1回だけ生成し、Command registry、router、Handlerへ渡す
 
 ### Message Handling Strategy
 

--- a/README.md
+++ b/README.md
@@ -227,9 +227,10 @@ docker-compose down -v
 ## プロジェクト構成
 
 - `src/`: ソースコード
-  - `app.ts`: Boltアプリケーションの設定
-  - `index.ts`: DB・Repository・Service・Command・Handlerを組み立てるエントリーポイント
-  - `config/`: 設定関連
+  - `index.ts`: 環境変数とプロセス終了処理を扱うエントリーポイント
+  - `app.ts`: 起動設定からBoltアプリケーションを生成するFactory
+  - `runtime.ts`: DB・Repository・Service・Command・Handlerの組み立てとリソース管理
+  - `config/`: 環境変数から起動設定を生成する処理
   - `db/`: データベース接続・スキーマ管理
   - `models/`: 永続化対象のデータ型
   - `repositories/`: SQLiteへのデータアクセスとトランザクション

--- a/src/app.spec.ts
+++ b/src/app.spec.ts
@@ -1,95 +1,80 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { App } from '@slack/bolt';
-import dotenv from 'dotenv';
+import type { Logger } from '@slack/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppConfig } from './config/appConfig';
 
-// モックの作成
-vi.mock('@slack/bolt', () => {
-  const MockApp = vi.fn().mockImplementation(function () {
-    return {
-      message: vi.fn().mockReturnThis(),
-      event: vi.fn().mockReturnThis(),
-      start: vi.fn().mockResolvedValue(undefined),
-    };
-  });
-  return { App: MockApp };
+const { appConstructor, appInstance } = vi.hoisted(() => {
+  const appInstance = {
+    message: vi.fn(),
+    event: vi.fn(),
+    start: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    appConstructor: vi.fn(function MockApp() {
+      return appInstance;
+    }),
+    appInstance,
+  };
 });
 
-vi.mock('dotenv', () => ({
-  default: {
-    config: vi.fn(),
-  },
+vi.mock('@slack/bolt', () => ({
+  App: appConstructor,
 }));
 
-describe('Slackアプリケーション', () => {
-  // 各テスト前に環境をクリーンアップ
+import { createSlackApp } from './app';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  setLevel: vi.fn(),
+  getLevel: vi.fn(),
+  setName: vi.fn(),
+} as unknown as Logger;
+
+const baseConfig: AppConfig = {
+  botToken: 'test-bot-token',
+  signingSecret: 'test-signing-secret',
+  appToken: 'test-app-token',
+  socketMode: true,
+  port: 3000,
+};
+
+describe('createSlackApp', () => {
   beforeEach(() => {
-    vi.resetModules();
     vi.clearAllMocks();
-    process.env.SLACK_BOT_TOKEN = 'test-bot-token';
-    process.env.SLACK_SIGNING_SECRET = 'test-signing-secret';
-    process.env.SLACK_APP_TOKEN = 'test-app-token';
   });
 
-  // 各テスト後に環境変数をクリア
-  afterEach(() => {
-    delete process.env.SLACK_BOT_TOKEN;
-    delete process.env.SLACK_SIGNING_SECRET;
-    delete process.env.SLACK_APP_TOKEN;
-    delete process.env.SLACK_SOCKET_MODE;
-  });
+  it('Socket Mode設定からSlack Appを作成する', () => {
+    const app = createSlackApp(baseConfig, logger);
 
-  it('Slackアプリが正しく初期化されること', () => {
-    // dotenvの設定を手動で呼び出す
-    dotenv.config();
-
-    // Slackアプリの初期化をシミュレート
-    const app = new App({
-      token: process.env.SLACK_BOT_TOKEN,
-      signingSecret: process.env.SLACK_SIGNING_SECRET,
-      socketMode: process.env.SLACK_SOCKET_MODE !== 'false',
-      appToken: process.env.SLACK_APP_TOKEN,
-    });
-
-    // dotenv.configが呼ばれたことを確認
-    expect(dotenv.config).toHaveBeenCalled();
-
-    // Appコンストラクタが正しいパラメータで呼ばれたか確認
-    expect(App).toHaveBeenCalledWith({
+    expect(appConstructor).toHaveBeenCalledWith({
       token: 'test-bot-token',
       signingSecret: 'test-signing-secret',
       socketMode: true,
       appToken: 'test-app-token',
+      logger,
     });
-
-    // appオブジェクトが正しく作成されたことを確認
-    expect(app).toBeDefined();
+    expect(app).toBe(appInstance);
   });
 
-  it('SLACK_SOCKET_MODE=falseに設定したときに`socketMode: false`に設定されること', () => {
-    // dotenvの設定を手動で呼び出す
-    dotenv.config();
-    process.env.SLACK_SOCKET_MODE = 'false';
+  it('HTTP Mode設定では未指定のApp Tokenをそのまま渡す', () => {
+    createSlackApp(
+      {
+        ...baseConfig,
+        appToken: undefined,
+        socketMode: false,
+      },
+      logger,
+    );
 
-    // Slackアプリの初期化をシミュレート
-    const app = new App({
-      token: process.env.SLACK_BOT_TOKEN,
-      signingSecret: process.env.SLACK_SIGNING_SECRET,
-      socketMode: process.env.SLACK_SOCKET_MODE !== 'false',
-      appToken: process.env.SLACK_APP_TOKEN,
-    });
-
-    // dotenv.configが呼ばれたことを確認
-    expect(dotenv.config).toHaveBeenCalled();
-
-    // Appコンストラクタが正しいパラメータで呼ばれたか確認
-    expect(App).toHaveBeenCalledWith({
+    expect(appConstructor).toHaveBeenCalledWith({
       token: 'test-bot-token',
       signingSecret: 'test-signing-secret',
       socketMode: false,
-      appToken: 'test-app-token',
+      appToken: undefined,
+      logger,
     });
-
-    // appオブジェクトが正しく作成されたことを確認
-    expect(app).toBeDefined();
   });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,31 +1,16 @@
 import { App } from '@slack/bolt';
-import dotenv from 'dotenv';
-import { logger } from './utils/logger';
+import type { Logger } from '@slack/logger';
+import type { AppConfig } from './config/appConfig';
 
-// 環境変数の読み込み
-dotenv.config();
-
-// 必要な環境変数の確認
-const { SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, SLACK_APP_TOKEN, SLACK_SOCKET_MODE } = process.env;
-const socketMode = SLACK_SOCKET_MODE !== 'false';
-
-if (!SLACK_BOT_TOKEN || !SLACK_SIGNING_SECRET || (socketMode && !SLACK_APP_TOKEN)) {
-  logger.error('必要な環境変数が設定されていません', {
-    required: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET', socketMode && 'SLACK_APP_TOKEN'].filter(
-      Boolean,
-    ),
-    socketMode,
+/**
+ * 起動設定からSlack Boltアプリケーションを作成する。
+ */
+export function createSlackApp(config: AppConfig, logger: Logger): App {
+  return new App({
+    token: config.botToken,
+    signingSecret: config.signingSecret,
+    socketMode: config.socketMode,
+    appToken: config.appToken,
+    logger,
   });
-  process.exit(1);
 }
-
-// Boltアプリの初期化（統一loggerを注入）
-const app = new App({
-  token: SLACK_BOT_TOKEN,
-  signingSecret: SLACK_SIGNING_SECRET,
-  socketMode: socketMode,
-  appToken: SLACK_APP_TOKEN,
-  logger: logger, // 統一loggerインスタンスを使用
-});
-
-export default app;

--- a/src/config/appConfig.spec.ts
+++ b/src/config/appConfig.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { AppConfigurationError, loadAppConfig } from './appConfig';
+
+describe('loadAppConfig', () => {
+  it('Socket Modeを既定値として設定を読み込む', () => {
+    expect(
+      loadAppConfig({
+        SLACK_BOT_TOKEN: 'bot-token',
+        SLACK_SIGNING_SECRET: 'signing-secret',
+        SLACK_APP_TOKEN: 'app-token',
+      }),
+    ).toEqual({
+      botToken: 'bot-token',
+      signingSecret: 'signing-secret',
+      appToken: 'app-token',
+      socketMode: true,
+      port: 3000,
+    });
+  });
+
+  it('HTTP ModeではApp Tokenを必須としない', () => {
+    expect(
+      loadAppConfig({
+        SLACK_BOT_TOKEN: 'bot-token',
+        SLACK_SIGNING_SECRET: 'signing-secret',
+        SLACK_SOCKET_MODE: 'false',
+        PORT: '8080',
+      }),
+    ).toEqual({
+      botToken: 'bot-token',
+      signingSecret: 'signing-secret',
+      appToken: undefined,
+      socketMode: false,
+      port: 8080,
+    });
+  });
+
+  it('false以外のSocket Mode設定は従来どおり有効として扱う', () => {
+    expect(
+      loadAppConfig({
+        SLACK_BOT_TOKEN: 'bot-token',
+        SLACK_SIGNING_SECRET: 'signing-secret',
+        SLACK_APP_TOKEN: 'app-token',
+        SLACK_SOCKET_MODE: 'FALSE',
+      }).socketMode,
+    ).toBe(true);
+  });
+
+  it('PORTは従来どおり10進整数へ変換する', () => {
+    expect(
+      loadAppConfig({
+        SLACK_BOT_TOKEN: 'bot-token',
+        SLACK_SIGNING_SECRET: 'signing-secret',
+        SLACK_APP_TOKEN: 'app-token',
+        PORT: '8080px',
+      }).port,
+    ).toBe(8080);
+  });
+
+  it('Socket Modeの必須設定が不足している場合は必要項目を返す', () => {
+    expect(() =>
+      loadAppConfig({
+        SLACK_SIGNING_SECRET: 'signing-secret',
+        SLACK_APP_TOKEN: 'app-token',
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        name: 'AppConfigurationError',
+        message: '必要な環境変数が設定されていません',
+        required: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_APP_TOKEN'],
+        socketMode: true,
+      }) satisfies Partial<AppConfigurationError>,
+    );
+  });
+
+  it('HTTP Modeの必須設定にApp Tokenを含めない', () => {
+    expect(() =>
+      loadAppConfig({
+        SLACK_BOT_TOKEN: 'bot-token',
+        SLACK_SOCKET_MODE: 'false',
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        required: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET'],
+        socketMode: false,
+      }) satisfies Partial<AppConfigurationError>,
+    );
+  });
+});

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -1,0 +1,41 @@
+export interface AppConfig {
+  botToken: string;
+  signingSecret: string;
+  appToken: string | undefined;
+  socketMode: boolean;
+  port: number;
+}
+
+export class AppConfigurationError extends Error {
+  constructor(
+    readonly required: string[],
+    readonly socketMode: boolean,
+  ) {
+    super('必要な環境変数が設定されていません');
+    this.name = 'AppConfigurationError';
+  }
+}
+
+/**
+ * 環境変数をアプリケーションの起動設定へ変換する。
+ */
+export function loadAppConfig(env: NodeJS.ProcessEnv): AppConfig {
+  const socketMode = env.SLACK_SOCKET_MODE !== 'false';
+  const required = [
+    'SLACK_BOT_TOKEN',
+    'SLACK_SIGNING_SECRET',
+    ...(socketMode ? ['SLACK_APP_TOKEN'] : []),
+  ];
+
+  if (!env.SLACK_BOT_TOKEN || !env.SLACK_SIGNING_SECRET || (socketMode && !env.SLACK_APP_TOKEN)) {
+    throw new AppConfigurationError(required, socketMode);
+  }
+
+  return {
+    botToken: env.SLACK_BOT_TOKEN,
+    signingSecret: env.SLACK_SIGNING_SECRET,
+    appToken: env.SLACK_APP_TOKEN,
+    socketMode,
+    port: env.PORT ? parseInt(env.PORT, 10) : 3000,
+  };
+}

--- a/src/db/connection.spec.ts
+++ b/src/db/connection.spec.ts
@@ -1,3 +1,4 @@
+import type Database from 'better-sqlite3';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -6,9 +7,18 @@ import { closeDatabase, openDatabase } from './connection';
 
 describe('database connection', () => {
   let temporaryDirectory: string | undefined;
+  const databases: Database.Database[] = [];
+
+  const openTrackedDatabase = (dbPath?: string): Database.Database => {
+    const database = dbPath === undefined ? openDatabase() : openDatabase(dbPath);
+    databases.push(database);
+    return database;
+  };
 
   afterEach(() => {
-    closeDatabase();
+    for (const database of databases.splice(0)) {
+      closeDatabase(database);
+    }
     if (temporaryDirectory) {
       fs.rmSync(temporaryDirectory, { recursive: true, force: true });
       temporaryDirectory = undefined;
@@ -17,33 +27,34 @@ describe('database connection', () => {
   });
 
   it('in-memory接続で外部キー制約を有効にすること', () => {
-    const db = openDatabase(':memory:');
+    const db = openTrackedDatabase(':memory:');
 
     expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
   });
 
-  it('開かれている接続を再利用すること', () => {
-    const first = openDatabase(':memory:');
+  it('呼び出しごとに独立した接続を開くこと', () => {
+    const first = openTrackedDatabase(':memory:');
+    const second = openTrackedDatabase(':memory:');
 
-    expect(openDatabase(':memory:')).toBe(first);
+    expect(second).not.toBe(first);
+    closeDatabase(first);
+    expect(first.open).toBe(false);
+    expect(second.open).toBe(true);
   });
 
-  it('終了後に新しい接続を開けること', () => {
-    const first = openDatabase(':memory:');
-    closeDatabase();
+  it('同じ接続を複数回閉じても安全であること', () => {
+    const db = openTrackedDatabase(':memory:');
 
-    expect(openDatabase(':memory:')).not.toBe(first);
-  });
+    closeDatabase(db);
 
-  it('未接続でも安全に終了できること', () => {
-    expect(() => closeDatabase()).not.toThrow();
+    expect(() => closeDatabase(db)).not.toThrow();
   });
 
   it('ファイルDBの親ディレクトリを作成すること', () => {
     temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'trrbot-db-'));
     const dbPath = path.join(temporaryDirectory, 'nested', 'test.db');
 
-    openDatabase(dbPath);
+    openTrackedDatabase(dbPath);
 
     expect(fs.existsSync(dbPath)).toBe(true);
   });
@@ -52,7 +63,7 @@ describe('database connection', () => {
     temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'trrbot-default-db-'));
     vi.spyOn(process, 'cwd').mockReturnValue(temporaryDirectory);
 
-    openDatabase();
+    openTrackedDatabase();
 
     expect(fs.existsSync(path.join(temporaryDirectory, 'data', 'trrbot.db'))).toBe(true);
   });

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('database');
-let instance: Database.Database | undefined;
 
 const defaultDatabasePath = (): string => path.resolve(process.cwd(), 'data', 'trrbot.db');
 
@@ -12,29 +11,23 @@ const defaultDatabasePath = (): string => path.resolve(process.cwd(), 'data', 't
  * アプリケーションで共有するデータベース接続を開く
  */
 export const openDatabase = (dbPath: string = defaultDatabasePath()): Database.Database => {
-  if (instance) {
-    return instance;
-  }
-
   if (dbPath !== ':memory:') {
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   }
 
-  instance = new Database(dbPath);
-  instance.pragma('foreign_keys = ON');
-  return instance;
+  const database = new Database(dbPath);
+  database.pragma('foreign_keys = ON');
+  return database;
 };
 
 /**
- * データベース接続を閉じる
+ * 指定したデータベース接続を閉じる
  */
-export const closeDatabase = (): void => {
-  if (!instance) {
+export const closeDatabase = (database: Database.Database): void => {
+  if (!database.open) {
     return;
   }
 
-  const database = instance;
-  instance = undefined;
   database.close();
   logger.info('データベース接続クローズ');
 };

--- a/src/db/schema.spec.ts
+++ b/src/db/schema.spec.ts
@@ -11,7 +11,7 @@ describe('database schema', () => {
   });
 
   afterEach(() => {
-    closeDatabase();
+    closeDatabase(db);
   });
 
   it('必要なテーブルを作成すること', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,60 +1,48 @@
-import app from './app';
-import { createCommandRegistry } from './commands';
-import { createCommandRouter } from './commands/router';
-import { closeDatabase, openDatabase } from './db/connection';
-import { initializeSchema } from './db/schema';
-import { registerMessageHandlers } from './handlers/messageHandler';
-import { registerMentionHandlers } from './handlers/mentionHandler';
-import { SqliteGroupRepository } from './repositories/sqliteGroupRepository';
-import { SqliteReactionMappingRepository } from './repositories/sqliteReactionMappingRepository';
-import { GroupService } from './services/groupService';
-import { ReactionService } from './services/reactionService';
-import { createLogger } from './utils/logger';
+import 'dotenv/config';
+import { createSlackApp } from './app';
+import { AppConfigurationError, loadAppConfig } from './config/appConfig';
+import { openDatabase } from './db/connection';
+import { createApplicationRuntime } from './runtime';
+import { createLogger, logger as slackLogger } from './utils/logger';
 import { getRandomItem } from './utils/random';
 
-const logger = createLogger('app');
+const appLogger = createLogger('app');
 
-// アプリの起動
-(async () => {
+async function main(): Promise<void> {
   try {
+    const config = loadAppConfig(process.env);
+    const app = createSlackApp(config, slackLogger);
     const db = openDatabase();
-    initializeSchema(db);
+    const runtime = createApplicationRuntime({ app, db, pickRandomItem: getRandomItem });
 
-    const groupService = new GroupService(new SqliteGroupRepository(db), getRandomItem);
-    const reactionService = new ReactionService(new SqliteReactionMappingRepository(db));
-    const commandRegistry = createCommandRegistry({ groupService, reactionService });
-    const processCommand = createCommandRouter(commandRegistry.resolveCommand);
+    const shutdown = (signal: 'SIGINT' | 'SIGTERM'): never => {
+      appLogger.info(`アプリを終了します（${signal}）`);
+      runtime.stop();
+      process.exit(0);
+    };
 
-    // メッセージハンドラの登録
-    registerMessageHandlers(app, { processCommand, reactionService });
+    process.on('SIGINT', () => shutdown('SIGINT'));
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
 
-    // メンションハンドラの登録
-    registerMentionHandlers(app, { processCommand });
-
-    const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
-    await app.start(port);
-    logger.info('Boltアプリ起動', {
-      port,
-      mode: process.env.SLACK_SOCKET_MODE !== 'false' ? 'socket' : 'http',
+    await runtime.start(config.port);
+    appLogger.info('Boltアプリ起動', {
+      port: config.port,
+      mode: config.socketMode ? 'socket' : 'http',
     });
   } catch (error) {
-    logger.error('アプリ起動失敗', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    closeDatabase();
+    if (error instanceof AppConfigurationError) {
+      slackLogger.error(error.message, {
+        required: error.required,
+        socketMode: error.socketMode,
+      });
+    } else {
+      appLogger.error('アプリ起動失敗', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     process.exit(1);
   }
-})();
+}
 
-// プロセス終了時の処理
-process.on('SIGINT', () => {
-  logger.info('アプリを終了します（SIGINT）');
-  closeDatabase();
-  process.exit(0);
-});
-
-process.on('SIGTERM', () => {
-  logger.info('アプリを終了します（SIGTERM）');
-  closeDatabase();
-  process.exit(0);
-});
+void main();

--- a/src/runtime.spec.ts
+++ b/src/runtime.spec.ts
@@ -1,0 +1,90 @@
+import type { App } from '@slack/bolt';
+import type Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { openDatabase } from './db/connection';
+import { createApplicationRuntime } from './runtime';
+
+describe('ApplicationRuntime', () => {
+  let db: Database.Database;
+  let app: App;
+  let message: ReturnType<typeof vi.fn>;
+  let event: ReturnType<typeof vi.fn>;
+  let start: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    db = openDatabase(':memory:');
+    message = vi.fn();
+    event = vi.fn();
+    start = vi.fn().mockResolvedValue(undefined);
+    app = { message, event, start } as unknown as App;
+  });
+
+  afterEach(() => {
+    if (db.open) {
+      db.close();
+    }
+  });
+
+  it('スキーマと依存関係を組み立ててHandlerを登録する', () => {
+    const runtime = createApplicationRuntime({
+      app,
+      db,
+      pickRandomItem: (items) => items[0],
+    });
+
+    const tables = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .all() as Array<{ name: string }>;
+
+    expect(tables).toEqual([
+      { name: 'group_items' },
+      { name: 'groups' },
+      { name: 'reaction_mappings' },
+    ]);
+    expect(message).toHaveBeenCalledOnce();
+    expect(event).toHaveBeenCalledWith('app_mention', expect.any(Function));
+
+    runtime.stop();
+  });
+
+  it('指定されたポートでSlack Appを起動する', async () => {
+    const runtime = createApplicationRuntime({
+      app,
+      db,
+      pickRandomItem: (items) => items[0],
+    });
+
+    await runtime.start(8080);
+
+    expect(start).toHaveBeenCalledWith(8080);
+    runtime.stop();
+  });
+
+  it('起動に失敗した場合はDB接続を閉じて例外を再送出する', async () => {
+    const error = new Error('start failed');
+    start.mockRejectedValue(error);
+    const runtime = createApplicationRuntime({
+      app,
+      db,
+      pickRandomItem: (items) => items[0],
+    });
+
+    await expect(runtime.start(3000)).rejects.toBe(error);
+    expect(db.open).toBe(false);
+  });
+
+  it('終了処理を複数回呼び出してもDB接続を一度だけ閉じる', () => {
+    const runtime = createApplicationRuntime({
+      app,
+      db,
+      pickRandomItem: (items) => items[0],
+    });
+
+    runtime.stop();
+
+    expect(db.open).toBe(false);
+    expect(() => runtime.stop()).not.toThrow();
+  });
+});

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,69 @@
+import type { App } from '@slack/bolt';
+import type Database from 'better-sqlite3';
+import { createCommandRegistry } from './commands';
+import { createCommandRouter } from './commands/router';
+import { closeDatabase } from './db/connection';
+import { initializeSchema } from './db/schema';
+import { registerMessageHandlers } from './handlers/messageHandler';
+import { registerMentionHandlers } from './handlers/mentionHandler';
+import { SqliteGroupRepository } from './repositories/sqliteGroupRepository';
+import { SqliteReactionMappingRepository } from './repositories/sqliteReactionMappingRepository';
+import { GroupService, type RandomItemPicker } from './services/groupService';
+import { ReactionService } from './services/reactionService';
+
+export interface ApplicationRuntimeDependencies {
+  app: App;
+  db: Database.Database;
+  pickRandomItem: RandomItemPicker;
+}
+
+export interface ApplicationRuntime {
+  start(port: number): Promise<void>;
+  stop(): void;
+}
+
+/**
+ * アプリケーションの依存関係を組み立て、所有するリソースのライフサイクルを管理する。
+ */
+export function createApplicationRuntime(
+  dependencies: ApplicationRuntimeDependencies,
+): ApplicationRuntime {
+  const { app, db, pickRandomItem } = dependencies;
+  let stopped = false;
+
+  const stop = (): void => {
+    if (stopped) {
+      return;
+    }
+
+    stopped = true;
+    closeDatabase(db);
+  };
+
+  try {
+    initializeSchema(db);
+
+    const groupService = new GroupService(new SqliteGroupRepository(db), pickRandomItem);
+    const reactionService = new ReactionService(new SqliteReactionMappingRepository(db));
+    const commandRegistry = createCommandRegistry({ groupService, reactionService });
+    const processCommand = createCommandRouter(commandRegistry.resolveCommand);
+
+    registerMessageHandlers(app, { processCommand, reactionService });
+    registerMentionHandlers(app, { processCommand });
+  } catch (error) {
+    stop();
+    throw error;
+  }
+
+  return {
+    async start(port: number): Promise<void> {
+      try {
+        await app.start(port);
+      } catch (error) {
+        stop();
+        throw error;
+      }
+    },
+    stop,
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       external: [
         '@slack/bolt',
         'dotenv',
+        'dotenv/config',
         'better-sqlite3',
         'pino',
         'pino-pretty',


### PR DESCRIPTION
## Implementation Summary

- GroupおよびReactionのSQL処理をSQLite Repositoryへ移し、Modelをデータ型の定義に限定した。
- GroupServiceとReactionServiceをインスタンス化し、Repositoryをコンストラクタから受け取る構成へ変更した。
- Command、Command Registry、Router、Handlerの依存関係を明示し、モジュールのstatic参照を使わずに組み立てるようにした。
- 複数グループアイテムの追加をRepositoryのトランザクションとして実装し、途中で失敗した場合のロールバックを保証した。
- 環境変数の解釈を副作用のないAppConfig生成処理へ分離し、Slack Appを設定とLoggerから生成するFactoryへ変更した。
- ApplicationRuntimeをcomposition rootとし、Repository、Service、Command、Handlerの組み立てとDB接続のライフサイクルを管理するようにした。
- DB接続のmodule singletonを廃止し、呼び出しごとに独立した接続を返して、閉じる接続を明示するAPIへ変更した。
- 起動失敗時とSIGINT／SIGTERM受信時に、ApplicationRuntimeが所有するDB接続を確実かつ冪等に閉じるようにした。
- ServiceやCommandのテストを自プロジェクト内モジュールのモックから明示的なfake依存へ移行し、RepositoryとRuntimeには実SQLiteを使ったテストを追加した。
- READMEとCLAUDE.mdのアーキテクチャ説明を現行実装に合わせて更新した。

## Decisions

- DIコンテナやServiceContainerは導入せず、ApplicationRuntimeで依存関係を組み立てる手動DIを採用した。現在の規模で必要な依存関係を明示しつつ、汎用的なコンテナ機構を持ち込まないため。
- SQLとトランザクションの所有者をRepositoryとした。Serviceをユースケースの判断に集中させ、永続化方式への依存を境界内へ閉じ込めるため。
- GroupとReactionを同じ変更で移行した。一方だけにstaticアクセスを残し、二つの依存管理方式が混在する状態を避けるため。
- 起動設定の解釈、Slack App生成、依存関係の組み立て、プロセス終了判断を別々の責務とした。import時の副作用を除き、プロセスや実環境変数を操作せずに各責務を検証できるようにするため。
- DB接続は暗黙的に再利用せず、ApplicationRuntimeが明示的に所有する構成とした。生成した接続と終了対象を一致させ、テスト間や複数Runtime間の状態共有を防ぐため。
- `SLACK_SOCKET_MODE=false`だけがHTTP Modeになる判定と、`parseInt`によるPORT変換は現行挙動として維持した。今回の変更をリファクタリングに限定するため。
- 既存の`feature/55`実装の取り込みやcherry-pickは行わず、現在のコードを基準に必要な責務分離だけを実装した。