### PR TITLE
ci: #188 CI/CDパイプラインを高速化しTrivyを導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,18 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   HUSKY: 0
 
 permissions:
-  contents: read   # actions/checkout@v7 と actions/cache@v6 に必要
+  contents: read
 
 jobs:
-  setup:
+  quality:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -24,71 +28,9 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      # キャッシュするnode_modulesを保存
-      - name: Cache node_modules
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        id: node-modules-cache
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-    outputs:
-      cache-hit: ${{ steps.node-modules-cache.outputs.cache-hit }}
-
-  lint:
-    needs: setup
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: '24'
-      # キャッシュされたnode_modulesを復元
-      - name: Restore node_modules
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Run ESLint
         run: npm run lint
-
-  test:
-    needs: setup
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: '24'
-      # better-sqlite3のビルドに必要なパッケージをインストール
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3 make g++
-      # キャッシュされたnode_modulesを復元
-      - name: Restore node_modules
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Run tests
-        run: npm run test
-
-  build:
-    needs: [lint, test]
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: '24'
-      # キャッシュされたnode_modulesを復元
-      - name: Restore node_modules
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+        run: npm test
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,34 @@ env:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   quality:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Scan dependencies for vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_INCLUDE_DEV_DEPS: 'true'
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'vuln'
+          version: 'v0.72.0'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          ignore-unfixed: 'true'
+          exit-code: '1'
+          cache: 'true'
+      - name: Upload Trivy results to GitHub Code Scanning
+        if: ${{ always() && hashFiles('trivy-results.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'trivy-npm'
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - 'v*.*.*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type == 'branch' }}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -21,6 +25,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to Container Registry
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
@@ -40,6 +47,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -48,3 +56,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=trrbot-ts-bolt
+          cache-to: type=gha,scope=trrbot-ts-bolt,mode=max

--- a/README.md
+++ b/README.md
@@ -126,15 +126,27 @@ CI環境（GitHub Actions等）でGit Hooksをスキップするには、`HUSKY=
 本プロジェクトのCIワークフローでは既に設定済みです：
 
 ```yaml
+env:
+  HUSKY: 0
+
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    env:
-      HUSKY: 0 # Git Hooksをスキップ
+  quality:
+    runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Run ESLint
+        run: npm run lint
+      - name: Run tests
+        run: npm test
+      - name: Build
+        run: npm run build
 ```
 
 ## Dockerを使用したデプロイ
@@ -143,9 +155,16 @@ jobs:
 
 このプロジェクトのDockerイメージはGitHub Container Registryで公開されています。
 
+- `latest`: `main`ブランチで最後に公開に成功したイメージ
+- `stable`: SemVerタグで最後に公開に成功したイメージ
+- バージョン番号: 指定したリリースのイメージ
+
 ```bash
-# 最新版を取得
+# mainブランチの最新ビルドを取得
 docker pull ghcr.io/ta-dadadada/trrbot-ts-bolt:latest
+
+# 最後に公開された安定版を取得
+docker pull ghcr.io/ta-dadadada/trrbot-ts-bolt:stable
 
 # 特定のバージョンを取得
 docker pull ghcr.io/ta-dadadada/trrbot-ts-bolt:1.0.0

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ git push --no-verify
 
 - **依存関係スキャン**: PRと`main`へのpushで、開発依存を含むnpm依存関係を検査
 - **CIゲート**: 修正版が存在するHIGHまたはCRITICALの脆弱性を検出した場合、CIを失敗させます
-- **GitHub連携**: 検査結果をGitHub Code Scanningへ送信し、Securityタブで管理
+- **GitHub連携**: 検査結果をGitHub Code Scanningへ送信し、Securityタブで管理。forkからのPRでは権限制約によりSARIF送信をスキップしますが、脆弱性検査とCIゲートは実行します
 
 #### Secret Scanning
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ git push --no-verify
 - **自動マージ**: パッチ・マイナーバージョンの更新は自動的にマージされます
 - **定期チェック**: 毎週月曜日 9:00 (JST)に依存関係をスキャン
 
+#### Trivy
+
+- **依存関係スキャン**: PRと`main`へのpushで、開発依存を含むnpm依存関係を検査
+- **CIゲート**: 修正版が存在するHIGHまたはCRITICALの脆弱性を検出した場合、CIを失敗させます
+- **GitHub連携**: 検査結果をGitHub Code Scanningへ送信し、Securityタブで管理
+
 #### Secret Scanning
 
 - **シークレット検出**: APIキーやトークンの誤コミットを自動検出
@@ -123,31 +129,7 @@ git push --no-verify
 
 CI環境（GitHub Actions等）でGit Hooksをスキップするには、`HUSKY=0`環境変数を設定します。
 
-本プロジェクトのCIワークフローでは既に設定済みです：
-
-```yaml
-env:
-  HUSKY: 0
-
-jobs:
-  quality:
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: '24'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
-      - name: Run ESLint
-        run: npm run lint
-      - name: Run tests
-        run: npm test
-      - name: Build
-        run: npm run build
-```
+本プロジェクトのCIワークフローでは設定済みです。
 
 ## Dockerを使用したデプロイ
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,7 @@ This project implements the following automated security measures:
 
 - **Dependabot Security Updates**: Automatically detects vulnerable dependencies and creates PRs
 - **Dependabot Auto-merge**: Automatically merges patch and minor security updates
+- **Trivy CI Gate**: Blocks fixable HIGH and CRITICAL vulnerabilities in all npm dependencies, including development dependencies, and uploads SARIF results to GitHub Code Scanning
 - **Secret Scanning**: Detects and prevents accidental commits of secrets (API keys, etc.)
 - **Scheduled Scans**: Weekly dependency vulnerability checks every Monday at 9:00 AM JST
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ This project implements the following automated security measures:
 
 - **Dependabot Security Updates**: Automatically detects vulnerable dependencies and creates PRs
 - **Dependabot Auto-merge**: Automatically merges patch and minor security updates
-- **Trivy CI Gate**: Blocks fixable HIGH and CRITICAL vulnerabilities in all npm dependencies, including development dependencies, and uploads SARIF results to GitHub Code Scanning
+- **Trivy CI Gate**: Blocks fixable HIGH and CRITICAL vulnerabilities in all npm dependencies, including development dependencies, and uploads SARIF results to GitHub Code Scanning. For pull requests from forks, the vulnerability scan and CI gate still run, but SARIF upload is skipped due to GitHub permission restrictions
 - **Secret Scanning**: Detects and prevents accidental commits of secrets (API keys, etc.)
 - **Scheduled Scans**: Weekly dependency vulnerability checks every Monday at 9:00 AM JST
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2360,16 +2360,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
     "vite": "^8.1.5",
     "vitest": "^4.1.10"
   },
+  "overrides": {
+    "minimatch": {
+      "brace-expansion": "5.0.8"
+    }
+  },
   "lint-staged": {
     "**/*.ts": [
       "eslint --fix",


### PR DESCRIPTION
## Implementation Summary

- CIのlint・test・buildを単一の`quality`ジョブへ統合し、依存関係のインストールとビルドの重複を削減
- CIとコンテナ公開ワークフローにconcurrency制御を追加
- Docker BuildxのGitHub Actionsキャッシュを導入
- `main`の正常なビルドを`latest`、SemVerタグの正常なビルドを`stable`として公開
- Trivyによるnpm依存関係の脆弱性検査をCIへ追加
  - 開発依存を含む
  - 修正可能なHIGH/CRITICALでCIを失敗させる
  - SARIFをGitHub Code Scanningへ送信する
- 既存のHIGH脆弱性を解消するため、`brace-expansion`を5.0.8へ更新
- READMEとSECURITY.mdを実際の運用方針に合わせて更新
- READMEに複製されていたGitHub Actions設定例を削除し、設定との二重管理を解消

## Decisions

- `latest`は、Dependabotによる脆弱性修正を速やかに公開できるよう、最新の正常な`main`ビルドを指す
- `stable`は、最後に正常公開されたSemVerタグのイメージを指す
- `main`ビルドとタグビルドは独立させ、タグ公開が過去のビルド結果に依存しない構成を維持する
- 同一コミットの再ビルドコストはBuildxキャッシュによって軽減する
- Trivyはコンテナイメージではなくファイルシステムを検査し、npm依存関係のゲートに限定する
- セキュリティ検査を既存の`quality`ジョブへ統合し、追加のrunner起動と必須チェックの増加を避ける
- forkからのPRでは権限制約によりSARIF送信を省略するが、脆弱性ゲート自体は実行する

## Verification

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `npm ci`
- `npm audit --audit-level=high` — 脆弱性0件
- Trivy HIGH/CRITICAL検査 — 脆弱性0件
- SARIF 2.1.0形式および結果0件を確認
- `npm run lint`
- `npm test` — 31ファイル、249テスト成功
- `npm run build`
- Dockerイメージのno-cacheビルド
- Dockerイメージの実行ユーザー、entrypoint、command、成果物、構文を確認

## Notes

- Refs #188