### PR TITLE
feat(config): #53: 起動設定の検証を強化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ SLACK_SIGNING_SECRET=your-signing-secret
 SLACK_APP_TOKEN=xapp-your-app-token  # ソケットモードに必要
 
 # アプリケーション設定
-PORT=3000
+SLACK_SOCKET_MODE=true  # true | false（デフォルト: true）
+PORT=3000  # 1〜65535の10進整数（デフォルト: 3000）
 
 # ボット設定
 BOT_MENTION_NAME=@trrbot  # ボットのメンション名（デフォルト: @trrbot）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Commands follow a class-based pattern implementing the `Command` interface (`src
 
 ### Socket Mode vs HTTP Mode
 
-The bot defaults to Socket Mode (WebSocket connection) but can switch to HTTP mode by setting `SLACK_SOCKET_MODE=false` in environment variables.
+ボットは既定でSocket Mode（WebSocket接続）を使用する。`SLACK_SOCKET_MODE` は `"true"` または `"false"` のみ受理し、`"false"` の場合はHTTP Modeを使用する。
 
 ### Build System
 
@@ -258,6 +258,6 @@ Required variables (see `.env.example`):
 - `SLACK_BOT_TOKEN`: Bot User OAuth Token
 - `SLACK_SIGNING_SECRET`: Signing secret from Slack
 - `SLACK_APP_TOKEN`: App-level token (required for Socket Mode)
-- `SLACK_SOCKET_MODE`: Set to `false` to use HTTP mode instead of Socket Mode (optional, defaults to true)
-- `PORT`: Port for HTTP server (default: 3000)
+- `SLACK_SOCKET_MODE`: `"true"` または `"false"`（省略時は `"true"`）
+- `PORT`: HTTPサーバーのポート番号。1〜65535の10進整数（省略時は `3000`）
 - `BOT_MENTION_NAME`: Bot mention name for help display (default: @trrbot)

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ cp .env.example .env
 SLACK_BOT_TOKEN=xoxb-your-bot-token
 SLACK_SIGNING_SECRET=your-signing-secret
 SLACK_APP_TOKEN=xapp-your-app-token
+SLACK_SOCKET_MODE=true
 PORT=3000
 LOG_LEVEL=info  # オプション: trace | debug | info | warn | error | fatal | silent（デフォルト: info）
 ```
@@ -193,7 +194,8 @@ LOG_LEVEL=info  # オプション: trace | debug | info | warn | error | fatal |
 - `SLACK_BOT_TOKEN`: Slack Bot User OAuth Token（必須）
 - `SLACK_SIGNING_SECRET`: Slack Signing Secret（必須）
 - `SLACK_APP_TOKEN`: Slack App-Level Token（Socket Mode使用時に必須）
-- `PORT`: HTTPサーバーのポート番号（デフォルト: 3000）
+- `SLACK_SOCKET_MODE`: `"true"` または `"false"`（デフォルト: `"true"`）
+- `PORT`: HTTPサーバーのポート番号。1〜65535の10進整数（デフォルト: `3000`）
 - `BOT_MENTION_NAME`: ヘルプメッセージ表示用のボットメンション名（デフォルト: @trrbot）
 - `LOG_LEVEL`: ログ出力レベル（オプション、大文字・小文字どちらでも可）
   - `trace`: 最も詳細なログ（パフォーマンストレース用）
@@ -284,7 +286,7 @@ docker-compose down -v
 
 このアプリはデフォルトではHTTPエンドポイントを公開せずに動作するため、「Socket Mode」をオンにします。これにより、WebSocketを使用してSlack APIと通信します。
 
-環境変数`SLACK_SOCKET_MODE=false`を設定した場合Socket Modeを利用しないHTTPベースでイベントを受け取る構成で起動します。
+環境変数 `SLACK_SOCKET_MODE` は未設定時に `"true"` として扱われます。`"false"` を設定すると、Socket Modeを利用しないHTTPベースでイベントを受け取る構成で起動します。それ以外の値は設定エラーになります。HTTP Modeでは `SLACK_APP_TOKEN` は不要です。
 
 ### トークンの取得
 

--- a/src/config/appConfig.spec.ts
+++ b/src/config/appConfig.spec.ts
@@ -1,21 +1,41 @@
 import { describe, expect, it } from 'vitest';
 import { AppConfigurationError, loadAppConfig } from './appConfig';
 
+const socketModeEnv: NodeJS.ProcessEnv = {
+  SLACK_BOT_TOKEN: 'bot-token',
+  SLACK_SIGNING_SECRET: 'signing-secret',
+  SLACK_APP_TOKEN: 'app-token',
+};
+
+function expectConfigurationError(env: NodeJS.ProcessEnv, variable: string, reason: string): void {
+  expect(() => loadAppConfig(env)).toThrow(
+    expect.objectContaining({
+      name: 'AppConfigurationError',
+      variable,
+      reason,
+      message: `${variable}: ${reason}`,
+    }) satisfies Partial<AppConfigurationError>,
+  );
+}
+
 describe('loadAppConfig', () => {
-  it('Socket Modeを既定値として設定を読み込む', () => {
-    expect(
-      loadAppConfig({
-        SLACK_BOT_TOKEN: 'bot-token',
-        SLACK_SIGNING_SECRET: 'signing-secret',
-        SLACK_APP_TOKEN: 'app-token',
-      }),
-    ).toEqual({
+  it('Socket ModeとPORTの既定値を設定する', () => {
+    expect(loadAppConfig(socketModeEnv)).toEqual({
       botToken: 'bot-token',
       signingSecret: 'signing-secret',
       appToken: 'app-token',
       socketMode: true,
       port: 3000,
     });
+  });
+
+  it('明示的にSocket Modeを有効にする', () => {
+    expect(
+      loadAppConfig({
+        ...socketModeEnv,
+        SLACK_SOCKET_MODE: 'true',
+      }).socketMode,
+    ).toBe(true);
   });
 
   it('HTTP ModeではApp Tokenを必須としない', () => {
@@ -35,55 +55,53 @@ describe('loadAppConfig', () => {
     });
   });
 
-  it('false以外のSocket Mode設定は従来どおり有効として扱う', () => {
-    expect(
-      loadAppConfig({
-        SLACK_BOT_TOKEN: 'bot-token',
-        SLACK_SIGNING_SECRET: 'signing-secret',
-        SLACK_APP_TOKEN: 'app-token',
-        SLACK_SOCKET_MODE: 'FALSE',
-      }).socketMode,
-    ).toBe(true);
-  });
-
-  it('PORTは従来どおり10進整数へ変換する', () => {
-    expect(
-      loadAppConfig({
-        SLACK_BOT_TOKEN: 'bot-token',
-        SLACK_SIGNING_SECRET: 'signing-secret',
-        SLACK_APP_TOKEN: 'app-token',
-        PORT: '8080px',
-      }).port,
-    ).toBe(8080);
-  });
-
-  it('Socket Modeの必須設定が不足している場合は必要項目を返す', () => {
-    expect(() =>
-      loadAppConfig({
-        SLACK_SIGNING_SECRET: 'signing-secret',
-        SLACK_APP_TOKEN: 'app-token',
-      }),
-    ).toThrow(
-      expect.objectContaining({
-        name: 'AppConfigurationError',
-        message: '必要な環境変数が設定されていません',
-        required: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_APP_TOKEN'],
-        socketMode: true,
-      }) satisfies Partial<AppConfigurationError>,
+  it.each([
+    ['SLACK_BOT_TOKEN', undefined],
+    ['SLACK_BOT_TOKEN', ''],
+    ['SLACK_SIGNING_SECRET', undefined],
+    ['SLACK_SIGNING_SECRET', ''],
+    ['SLACK_APP_TOKEN', undefined],
+    ['SLACK_APP_TOKEN', ''],
+  ])('%sが未設定または空文字の場合は拒否する', (variable, value) => {
+    expectConfigurationError(
+      {
+        ...socketModeEnv,
+        [variable]: value,
+      },
+      variable,
+      '値が設定されていません',
     );
   });
 
-  it('HTTP Modeの必須設定にApp Tokenを含めない', () => {
-    expect(() =>
-      loadAppConfig({
-        SLACK_BOT_TOKEN: 'bot-token',
-        SLACK_SOCKET_MODE: 'false',
-      }),
-    ).toThrow(
-      expect.objectContaining({
-        required: ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET'],
-        socketMode: false,
-      }) satisfies Partial<AppConfigurationError>,
+  it.each(['FALSE', '1', ''])('不正なSocket Mode設定 %j を拒否する', (value) => {
+    expectConfigurationError(
+      {
+        ...socketModeEnv,
+        SLACK_SOCKET_MODE: value,
+      },
+      'SLACK_SOCKET_MODE',
+      '"true" または "false" を指定してください',
     );
   });
+
+  it.each([
+    ['1', 1],
+    ['65535', 65535],
+  ])('PORTの境界値 %s を受理する', (value, expected) => {
+    expect(loadAppConfig({ ...socketModeEnv, PORT: value }).port).toBe(expected);
+  });
+
+  it.each(['0', '65536', '8080px', '1.5', '+3000', '-1', ''])(
+    '不正なPORT設定 %j を拒否する',
+    (value) => {
+      expectConfigurationError(
+        {
+          ...socketModeEnv,
+          PORT: value,
+        },
+        'PORT',
+        '1から65535までの10進整数を指定してください',
+      );
+    },
+  );
 });

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -6,36 +6,73 @@ export interface AppConfig {
   port: number;
 }
 
+type AppConfigVariable =
+  'SLACK_BOT_TOKEN' | 'SLACK_SIGNING_SECRET' | 'SLACK_APP_TOKEN' | 'SLACK_SOCKET_MODE' | 'PORT';
+
 export class AppConfigurationError extends Error {
   constructor(
-    readonly required: string[],
-    readonly socketMode: boolean,
+    readonly variable: AppConfigVariable,
+    readonly reason: string,
   ) {
-    super('必要な環境変数が設定されていません');
+    super(`${variable}: ${reason}`);
     this.name = 'AppConfigurationError';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 
-/**
- * 環境変数をアプリケーションの起動設定へ変換する。
- */
-export function loadAppConfig(env: NodeJS.ProcessEnv): AppConfig {
-  const socketMode = env.SLACK_SOCKET_MODE !== 'false';
-  const required = [
-    'SLACK_BOT_TOKEN',
-    'SLACK_SIGNING_SECRET',
-    ...(socketMode ? ['SLACK_APP_TOKEN'] : []),
-  ];
+function getRequiredString(env: NodeJS.ProcessEnv, variable: AppConfigVariable): string {
+  const value = env[variable];
 
-  if (!env.SLACK_BOT_TOKEN || !env.SLACK_SIGNING_SECRET || (socketMode && !env.SLACK_APP_TOKEN)) {
-    throw new AppConfigurationError(required, socketMode);
+  if (value === undefined || value === '') {
+    throw new AppConfigurationError(variable, '値が設定されていません');
   }
 
+  return value;
+}
+
+function parseSocketMode(value: string | undefined): boolean {
+  if (value === undefined || value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  throw new AppConfigurationError('SLACK_SOCKET_MODE', '"true" または "false" を指定してください');
+}
+
+function parsePort(value: string | undefined): number {
+  if (value === undefined) {
+    return 3000;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw new AppConfigurationError('PORT', '1から65535までの10進整数を指定してください');
+  }
+
+  const port = Number(value);
+  if (port < 1 || port > 65535) {
+    throw new AppConfigurationError('PORT', '1から65535までの10進整数を指定してください');
+  }
+
+  return port;
+}
+
+/**
+ * 環境変数を検証し、アプリケーションの起動設定へ変換する。
+ */
+export function loadAppConfig(env: NodeJS.ProcessEnv): AppConfig {
+  const socketMode = parseSocketMode(env.SLACK_SOCKET_MODE);
+  const botToken = getRequiredString(env, 'SLACK_BOT_TOKEN');
+  const signingSecret = getRequiredString(env, 'SLACK_SIGNING_SECRET');
+  const appToken = socketMode ? getRequiredString(env, 'SLACK_APP_TOKEN') : env.SLACK_APP_TOKEN;
+
   return {
-    botToken: env.SLACK_BOT_TOKEN,
-    signingSecret: env.SLACK_SIGNING_SECRET,
-    appToken: env.SLACK_APP_TOKEN,
+    botToken,
+    signingSecret,
+    appToken,
     socketMode,
-    port: env.PORT ? parseInt(env.PORT, 10) : 3000,
+    port: parsePort(env.PORT),
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,8 @@ async function main(): Promise<void> {
   } catch (error) {
     if (error instanceof AppConfigurationError) {
       slackLogger.error(error.message, {
-        required: error.required,
-        socketMode: error.socketMode,
+        variable: error.variable,
+        reason: error.reason,
       });
     } else {
       appLogger.error('アプリ起動失敗', {


### PR DESCRIPTION
## Implementation Summary

- 必須のSlack認証情報を起動時に検証する
- `SLACK_SOCKET_MODE` を `"true"` または `"false"` のみに制限する
- `PORT` を1〜65535の10進整数のみに制限する
- 設定エラーに環境変数名と理由を保持し、構造化ログへ出力する
- READMEと環境変数の設定例を新しい検証仕様へ同期する

## Decisions

- 対象項目が少ないため、実行時依存を追加せず目的別の小さな検証関数で実装した
- 設定エラーは `variable` と `reason` を公開し、ログから原因を特定できる形にした
- トークン形式の推測検証や汎用設定フレームワークは導入していない
## Notes

- 関連Issue: #53