### PR TITLE
fix: #55: DI導入後の終了処理と取得順を安定化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ npx vitest run src/path/to/file.spec.ts
 1. **Entry Point** (`src/index.ts`): `.env`を読み込み、起動設定、Slack App、DB接続、Application Runtimeを生成し、プロセスシグナルを処理する
 2. **App Configuration** (`src/config/appConfig.ts`): 環境変数を副作用のない起動設定へ変換する
 3. **Slack App Factory** (`src/app.ts`): 起動設定とLoggerからBolt Appを生成する
-4. **Application Runtime** (`src/runtime.ts`): Repository、Service、Command、Handlerを組み立て、起動とDB接続の終了を管理する
+4. **Application Runtime** (`src/runtime.ts`): Repository、Service、Command、Handlerを組み立て、Slack AppとDB接続のライフサイクルを管理する
 5. **Event Handlers**: Two main handler types registered at startup:
    - `mentionHandler`: Processes `app_mention` events
    - `messageHandler`: Handles all message events for DMs (processes as commands) and channel messages (applies automatic reactions)

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -8,7 +8,7 @@ const logger = createLogger('database');
 const defaultDatabasePath = (): string => path.resolve(process.cwd(), 'data', 'trrbot.db');
 
 /**
- * アプリケーションで共有するデータベース接続を開く
+ * 新しいデータベース接続を開く
  */
 export const openDatabase = (dbPath: string = defaultDatabasePath()): Database.Database => {
   if (dbPath !== ':memory:') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,26 @@ async function main(): Promise<void> {
     const db = openDatabase();
     const runtime = createApplicationRuntime({ app, db, pickRandomItem: getRandomItem });
 
-    const shutdown = (signal: 'SIGINT' | 'SIGTERM'): never => {
+    const shutdown = async (signal: 'SIGINT' | 'SIGTERM'): Promise<never> => {
       appLogger.info(`アプリを終了します（${signal}）`);
-      runtime.stop();
-      process.exit(0);
+
+      try {
+        await runtime.stop();
+        process.exit(0);
+      } catch (error) {
+        appLogger.error('アプリ終了失敗', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        process.exit(1);
+      }
     };
 
-    process.on('SIGINT', () => shutdown('SIGINT'));
-    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => {
+      void shutdown('SIGINT');
+    });
+    process.on('SIGTERM', () => {
+      void shutdown('SIGTERM');
+    });
 
     await runtime.start(config.port);
     appLogger.info('Boltアプリ起動', {

--- a/src/repositories/sqliteReactionMappingRepository.spec.ts
+++ b/src/repositories/sqliteReactionMappingRepository.spec.ts
@@ -30,6 +30,15 @@ describe('SqliteReactionMappingRepository', () => {
     ]);
   });
 
+  it('SQLiteの未指定順序に依存せず登録順で一覧取得する', () => {
+    const firstId = repository.create('first', ':one:');
+    const secondId = repository.create('second', ':two:');
+    const thirdId = repository.create('third', ':three:');
+    db.pragma('reverse_unordered_selects = ON');
+
+    expect(repository.getAll().map(({ id }) => id)).toEqual([firstId, secondId, thirdId]);
+  });
+
   it('トリガーとリアクションの組み合わせで削除する', () => {
     repository.create('hello', ':wave:');
 

--- a/src/repositories/sqliteReactionMappingRepository.ts
+++ b/src/repositories/sqliteReactionMappingRepository.ts
@@ -24,6 +24,7 @@ export class SqliteReactionMappingRepository implements ReactionMappingRepositor
         created_at as createdAt,
         updated_at as updatedAt
       FROM reaction_mappings
+      ORDER BY id ASC
     `);
 
     return statement.all() as ReactionMapping[];

--- a/src/runtime.spec.ts
+++ b/src/runtime.spec.ts
@@ -10,13 +10,15 @@ describe('ApplicationRuntime', () => {
   let message: ReturnType<typeof vi.fn>;
   let event: ReturnType<typeof vi.fn>;
   let start: ReturnType<typeof vi.fn>;
+  let stop: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     db = openDatabase(':memory:');
     message = vi.fn();
     event = vi.fn();
     start = vi.fn().mockResolvedValue(undefined);
-    app = { message, event, start } as unknown as App;
+    stop = vi.fn().mockResolvedValue(undefined);
+    app = { message, event, start, stop } as unknown as App;
   });
 
   afterEach(() => {
@@ -25,7 +27,7 @@ describe('ApplicationRuntime', () => {
     }
   });
 
-  it('スキーマと依存関係を組み立ててHandlerを登録する', () => {
+  it('スキーマと依存関係を組み立ててHandlerを登録する', async () => {
     const runtime = createApplicationRuntime({
       app,
       db,
@@ -46,7 +48,8 @@ describe('ApplicationRuntime', () => {
     expect(message).toHaveBeenCalledOnce();
     expect(event).toHaveBeenCalledWith('app_mention', expect.any(Function));
 
-    runtime.stop();
+    await runtime.stop();
+    expect(stop).not.toHaveBeenCalled();
   });
 
   it('指定されたポートでSlack Appを起動する', async () => {
@@ -59,7 +62,7 @@ describe('ApplicationRuntime', () => {
     await runtime.start(8080);
 
     expect(start).toHaveBeenCalledWith(8080);
-    runtime.stop();
+    await runtime.stop();
   });
 
   it('起動に失敗した場合はDB接続を閉じて例外を再送出する', async () => {
@@ -73,18 +76,65 @@ describe('ApplicationRuntime', () => {
 
     await expect(runtime.start(3000)).rejects.toBe(error);
     expect(db.open).toBe(false);
+    expect(stop).not.toHaveBeenCalled();
   });
 
-  it('終了処理を複数回呼び出してもDB接続を一度だけ閉じる', () => {
+  it('起動後はSlack Appの停止を待ってからDB接続を閉じる', async () => {
+    let completeStop: (() => void) | undefined;
+    stop.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          completeStop = resolve;
+        }),
+    );
     const runtime = createApplicationRuntime({
       app,
       db,
       pickRandomItem: (items) => items[0],
     });
+    await runtime.start(3000);
 
-    runtime.stop();
+    const stopping = runtime.stop();
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(db.open).toBe(true);
+
+    completeStop?.();
+    await stopping;
 
     expect(db.open).toBe(false);
-    expect(() => runtime.stop()).not.toThrow();
+  });
+
+  it('並行して終了処理を呼び出しても同じ処理を共有する', async () => {
+    const runtime = createApplicationRuntime({
+      app,
+      db,
+      pickRandomItem: (items) => items[0],
+    });
+    await runtime.start(3000);
+
+    const firstStop = runtime.stop();
+    const secondStop = runtime.stop();
+
+    expect(firstStop).toBe(secondStop);
+    await Promise.all([firstStop, secondStop]);
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(db.open).toBe(false);
+  });
+
+  it('Slack Appの停止に失敗してもDB接続を閉じる', async () => {
+    const error = new Error('stop failed');
+    stop.mockRejectedValue(error);
+    const runtime = createApplicationRuntime({
+      app,
+      db,
+      pickRandomItem: (items) => items[0],
+    });
+    await runtime.start(3000);
+
+    await expect(runtime.stop()).rejects.toBe(error);
+
+    expect(db.open).toBe(false);
   });
 });

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -19,7 +19,7 @@ export interface ApplicationRuntimeDependencies {
 
 export interface ApplicationRuntime {
   start(port: number): Promise<void>;
-  stop(): void;
+  stop(): Promise<void>;
 }
 
 /**
@@ -29,15 +29,23 @@ export function createApplicationRuntime(
   dependencies: ApplicationRuntimeDependencies,
 ): ApplicationRuntime {
   const { app, db, pickRandomItem } = dependencies;
-  let stopped = false;
+  let started = false;
+  let stopPromise: Promise<void> | undefined;
 
-  const stop = (): void => {
-    if (stopped) {
-      return;
+  const stop = (): Promise<void> => {
+    if (stopPromise === undefined) {
+      stopPromise = (async () => {
+        try {
+          if (started) {
+            await app.stop();
+          }
+        } finally {
+          closeDatabase(db);
+        }
+      })();
     }
 
-    stopped = true;
-    closeDatabase(db);
+    return stopPromise;
   };
 
   try {
@@ -51,7 +59,7 @@ export function createApplicationRuntime(
     registerMessageHandlers(app, { processCommand, reactionService });
     registerMentionHandlers(app, { processCommand });
   } catch (error) {
-    stop();
+    closeDatabase(db);
     throw error;
   }
 
@@ -59,8 +67,9 @@ export function createApplicationRuntime(
     async start(port: number): Promise<void> {
       try {
         await app.start(port);
+        started = true;
       } catch (error) {
-        stop();
+        await stop();
         throw error;
       }
     },

--- a/src/services/reactionService.ts
+++ b/src/services/reactionService.ts
@@ -21,15 +21,18 @@ export class ReactionService implements ReactionOperations {
   findMatchingMappings(messageText: string): ReactionMapping[] {
     const allMappings = this.repository.getAll();
     const seenReactions = new Set<string>();
+    const matchingMappings: ReactionMapping[] = [];
 
-    return allMappings.filter((mapping) => {
+    for (const mapping of allMappings) {
       if (!messageText.includes(mapping.triggerText) || seenReactions.has(mapping.reaction)) {
-        return false;
+        continue;
       }
 
       seenReactions.add(mapping.reaction);
-      return true;
-    });
+      matchingMappings.push(mapping);
+    }
+
+    return matchingMappings;
   }
 
   addReactionMapping(triggerText: string, reaction: string): number {


### PR DESCRIPTION
## Summary

- ApplicationRuntimeの停止処理を非同期かつ冪等にし、Slack Appの停止完了後にDB接続を閉じるようにした
- Slack Appの停止に失敗した場合もDB接続を確実に閉じ、シグナル処理は停止完了を待って終了するようにした
- Reaction MappingをID昇順で取得し、同じリアクションに複数のトリガーが一致した場合の優先順を固定した
- ReactionServiceの副作用を伴うfilter処理とDB接続の古いJSDocを整理した
- Application Runtimeのライフサイクル責務に合わせてCLAUDE.mdを更新した

## Verification

- npm test（31 files / 267 tests passed）
- npm run lint
- npm run build
- npx prettier --check（変更ファイル）

## Review follow-up

PR #204とPR #205に残っていた4件のレビュー指摘へ対応する。

Closes #55